### PR TITLE
Add code coverage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+.phpunit.cache
 /vendor/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To run tests:
 composer test
 ```
 
+If you want to get a code coverage report from the tests, you can run `composer test_coverage`. You'll need to install the `php-xdebug` extension:
+
+```
+pecl install xdebug
+```
+
 To run linter:
 ```
 composer lint

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "squizlabs/php_codesniffer": "^3.5"
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit tests",
+        "test": "./vendor/bin/phpunit",
+        "test_coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-text",
         "lint": "./vendor/bin/phpcs --standard=PSR12 src"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
### WHY are these changes introduced?

We want to be able to extract code coverage from our unit tests to ensure we're covering as much as possible.

### WHAT is this pull request doing?

Configuring PHPUnit to print a coverage report.