### PR TITLE
Update CODEOWNERS to enable automatic review request tagging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shopify/platform-dev-tools-education
+*       @Shopify/platform-dev-tools-education


### PR DESCRIPTION
### WHY are these changes introduced?

- code owners are currently not requested for review

### WHAT is this pull request doing?

- add spaces between `*` and the DTE tag
    - this is a test PR, it might not solve the problem
> You can define code owners in public repositories with GitHub Free and GitHub Free for organizations, and in public and private repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server.

- if we have GitHub Free for organizations, codeowners will be tagged when this repo goes public 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
