### PR TITLE
Adding namespaces to tests and fixing coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,7 @@
         </testsuite>
     </testsuites>
 
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
+    <coverage cacheDirectory=".phpunit.cache/code-coverage">
         <include>
             <directory suffix=".php">src</directory>
         </include>

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -139,7 +139,7 @@ class Http
                 break;
         }
 
-        $version = require_once dirname(__FILE__) . '/../version.php';
+        $version = require dirname(__FILE__) . '/../version.php';
         $userAgent = "Shopify Admin API Library for PHP v{$version}";
         if (isset($headers['User-Agent'])) {
             $userAgent = "{$headers['User-Agent']} | $userAgent";

--- a/src/version.php
+++ b/src/version.php
@@ -1,3 +1,5 @@
 <?php
 
+// @codeCoverageIgnoreStart
 return '0.0.1';
+// @codeCoverageIgnoreEnd

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -152,7 +152,7 @@ final class HttpTest extends BaseTestCase
 
     public function testUserAgent()
     {
-        $version = require_once dirname(__FILE__) . '/../../src/version.php';
+        $version = require dirname(__FILE__) . '/../../src/version.php';
         $client = $this->getHttpClientWithMocks([
             $this->buildMockHttpResponse(200, $this->successResponse),
             $this->buildMockHttpResponse(200, $this->successResponse),

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -2,49 +2,51 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
+namespace ShopifyTest;
 
-final class UtilsTest extends TestCase
+use Shopify\Utils;
+
+final class UtilsTest extends BaseTestCase
 {
     public function testSanitizeShopDomainOnGoodShopDomains()
     {
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('my-shop'));
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('MY-SHOP'));
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('   My-ShOp   '));
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('my-shop.myshopify.com'));
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('http://my-shop.myshopify.com'));
-        $this->assertEquals('my-shop.myshopify.com', Shopify\Utils::sanitizeShopDomain('https://my-shop.myshopify.com'));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('my-shop'));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('MY-SHOP'));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('   My-ShOp   '));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('my-shop.myshopify.com'));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('http://my-shop.myshopify.com'));
+        $this->assertEquals('my-shop.myshopify.com', Utils::sanitizeShopDomain('https://my-shop.myshopify.com'));
     }
 
     public function testSanitizeShopDomainOnBadShopDomains()
     {
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('myshop.com'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('myshopify.com'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('shopify.com'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('my shop'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('store.myshopify.com.evil.com'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('/foo/bar'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('/foo.myshopify.io.evil.ru'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('%0a123.myshopify.io'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('foo.bar.myshopify.io'));
-        $this->assertEquals(null, Shopify\Utils::sanitizeShopDomain('https://my-shop.myshopify.com', 'myshopify.io'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('myshop.com'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('myshopify.com'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('shopify.com'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('my shop'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('store.myshopify.com.evil.com'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('/foo/bar'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('/foo.myshopify.io.evil.ru'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('%0a123.myshopify.io'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('foo.bar.myshopify.io'));
+        $this->assertEquals(null, Utils::sanitizeShopDomain('https://my-shop.myshopify.com', 'myshopify.io'));
     }
 
     public function testSanitizeShopDomainOnCustomShopDomains()
     {
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain('my-shop', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain('my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain('http://my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Shopify\Utils::sanitizeShopDomain(' MY-SHOP ', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('my-shop', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('my-shop.myshopify.io', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('http://my-shop.myshopify.io', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(' MY-SHOP ', 'myshopify.io'));
     }
 
     public function testValidHmac()
     {
         $url = 'https://123456.ngrok.io/auth/shopify/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=654619d4b5a4f54795c3f40db18e4ed8b825f0abce16d1d75ab57e10c5e09490&shop=some-shop.myshopify.com&state=0.6784241404160823&timestamp=1337178173';
-        $params = Shopify\Utils::getQueryParams($url);
-        $this->assertEquals(false, Shopify\Utils::validateHmac(
+        $params = Utils::getQueryParams($url);
+        $this->assertEquals(false, Utils::validateHmac(
             $params,
             'hush'
         ));
@@ -53,8 +55,8 @@ final class UtilsTest extends TestCase
     public function testInvalidHmac()
     {
         $url = 'https://123456.ngrok.io/auth/shopify/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=asdf&shop=some-shop.myshopify.com&state=0.6784241404160823&timestamp=1337178173';
-        $params = Shopify\Utils::getQueryParams($url);
-        $this->assertEquals(false, Shopify\Utils::validateHmac(
+        $params = Utils::getQueryParams($url);
+        $this->assertEquals(false, Utils::validateHmac(
             $params,
             'asdf'
         ));
@@ -68,13 +70,13 @@ final class UtilsTest extends TestCase
             "name" => "joe",
             "foo" => "bar"
         ];
-        $this->assertEquals($params, Shopify\Utils::getQueryParams('www.google.ca?abc=def&code=1234&name=joe&foo=bar'));
+        $this->assertEquals($params, Utils::getQueryParams('www.google.ca?abc=def&code=1234&name=joe&foo=bar'));
     }
 
     public function testGetBadQueryParams()
     {
-        $this->assertEquals([], Shopify\Utils::getQueryParams('google'));
-        $this->assertEquals([], Shopify\Utils::getQueryParams('www.google.ca'));
-        $this->assertEquals(['asdf' => ''], Shopify\Utils::getQueryParams('www.google.ca?asdf'));
+        $this->assertEquals([], Utils::getQueryParams('google'));
+        $this->assertEquals([], Utils::getQueryParams('www.google.ca'));
+        $this->assertEquals(['asdf' => ''], Utils::getQueryParams('www.google.ca?asdf'));
     }
 }


### PR DESCRIPTION
I learned that code coverage won't process folders if the folder name doesn't match the namespace exactly, which means we need to CamelCase folder names. By doing that, we no longer need to force PHPUnit to include uncovered files, which caused issues as more files were added.

While making these changes, I also made a couple of minor tweaks to the tests that were also causing breakages.