### PR TITLE
Add SessionStorage interface

### DIFF
--- a/src/Auth/SessionStorage.php
+++ b/src/Auth/SessionStorage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Auth;
+
+use Shopify\Auth\Session;
+
+interface SessionStorage
+{
+    /**
+     * Internally handles storing the given session object.
+     *
+     * @param Session $session The session to store
+     *
+     * @return bool Whether the operation succeeded
+     */
+    public function storeSession(Session $session): bool;
+
+    /**
+     * Internally handles loading the given session.
+     *
+     * @param string $sessionId The id of the session to load
+     *
+     * @return Session|null The session if it exists, null otherwise
+     */
+    public function loadSession(string $sessionId): Session | null;
+
+    /**
+     * Internally handles deleting the given session.
+     *
+     * @param string $sessionId The id of the session to delete
+     *
+     * @return bool Whether the operation succeeded
+     */
+    public function deleteSession(string $sessionId): bool;
+}

--- a/tests/Auth/MockSessionStorage.php
+++ b/tests/Auth/MockSessionStorage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Auth;
+
+use Shopify\Auth\Session;
+use Shopify\Auth\SessionStorage;
+
+final class MockSessionStorage implements SessionStorage
+{
+    private array $calls = [];
+    private array $testSessions = [];
+
+    public function storeSession(Session $session): bool
+    {
+        $this->calls[] = ['store', $session];
+        $this->testSessions[$session->getId()] = $session;
+        return true;
+    }
+
+    public function loadSession(string $sessionId): Session | null
+    {
+        $this->calls[] = ['load', $sessionId];
+        return $this->testSessions[$sessionId] ?? null;
+    }
+
+    public function deleteSession(string $sessionId): bool
+    {
+        $this->calls[] = ['delete', $sessionId];
+        unset($this->testSessions[$sessionId]);
+        return true;
+    }
+
+    /**
+     * Retrieves the calls made to this class for assertions.
+     *
+     * @return array
+     */
+    public function getCalls(): array
+    {
+        return $this->calls;
+    }
+}

--- a/tests/Auth/SessionStorageTest.php
+++ b/tests/Auth/SessionStorageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Auth;
+
+use Shopify\Auth\Session;
+use ShopifyTest\BaseTestCase;
+
+final class SessionStorageTest extends BaseTestCase
+{
+    private string $sessionId = 'test_session';
+    private Session $session;
+
+    public function setUp(): void
+    {
+        $this->session = new Session($this->sessionId);
+        $this->session->setShop('test-shop.myshopify.io');
+        $this->session->setState('1234');
+        $this->session->setScope('read_products');
+        $this->session->setExpires(strtotime('+1 day'));
+        $this->session->setIsOnline(true);
+        $this->session->setAccessToken('totally_real_access_token');
+    }
+
+    public function testStoreLoadDeleteSession()
+    {
+        $storage = new MockSessionStorage();
+
+        $this->assertEquals(null, $storage->loadSession($this->sessionId));
+        $this->assertEquals(true, $storage->storeSession($this->session));
+        $this->assertEquals($this->session, $storage->loadSession($this->sessionId));
+        $this->assertEquals(true, $storage->deleteSession($this->sessionId));
+        $this->assertEquals(
+            [
+                ['load',   $this->sessionId],
+                ['store',  $this->session],
+                ['load',   $this->sessionId],
+                ['delete', $this->sessionId],
+            ],
+            $storage->getCalls()
+        );
+    }
+}

--- a/tests/Auth/SessionTest.php
+++ b/tests/Auth/SessionTest.php
@@ -2,10 +2,16 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
-use Shopify\Auth\Session;
+namespace ShopifyTest\Auth;
 
-final class SessionTest extends TestCase
+use DateTime;
+use Shopify\Auth\Session;
+use ShopifyTest\BaseTestCase;
+
+/**
+ * @covers \Shopify\Auth\Session
+ */
+final class SessionTest extends BaseTestCase
 {
     public function testSessionGetterAndSetterFunctions()
     {
@@ -31,5 +37,20 @@ final class SessionTest extends TestCase
         $this->assertEquals(null, $session->getExpires());
         $this->assertEquals(false, $session->getIsOnline());
         $this->assertEquals(null, $session->getAccessToken());
+    }
+
+    public function testSetExpiresValues()
+    {
+        $date = new DateTime('@' . strtotime('+1 day'));
+        $session = new Session('12345');
+
+        $session->setExpires((int)$date->format('U'));
+        $this->assertEquals($date, $session->getExpires());
+
+        $session->setExpires($date->format('c'));
+        $this->assertEquals($date, $session->getExpires());
+
+        $session->setExpires($date);
+        $this->assertEquals($date, $session->getExpires());
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We need to be able to generically handle storing / loading sessions. By using an interface, we can have the library delegate the action so each app decides how that gets done.

### WHAT is this pull request doing?

Adding a `SessionStorage` interface to define the actions the library will expect to be able to perform with sessions.