### PR TITLE
Reworking HTTP client tests

### DIFF
--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -149,7 +149,7 @@ class Http
         ?int $tries = null,
     ): HttpResponse {
         $maxTries = $tries ?? 1;
-        $url = "{$this->domain}/$path";
+        $url = "https://{$this->domain}/$path";
 
         $ch = curl_init($url);
         $this->setCurlOption($ch, CURLOPT_RETURNTRANSFER, true);

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -33,7 +33,7 @@ final class HttpTest extends BaseTestCase
 
         $response = $client->get(path: 'test/path', headers: $headers);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions([CURLOPT_HTTPHEADER => ['X-Test-Header: test_value']], $this->curlOptions[0]);
+        $this->assertHttpRequest("{$this->domain}/test/path", [CURLOPT_HTTPHEADER => ['X-Test-Header: test_value']]);
     }
 
     public function testPostRequest()
@@ -49,7 +49,8 @@ final class HttpTest extends BaseTestCase
         $bodyLength = strlen(json_encode($this->product1));
         $response = $client->post(path: 'test/path', body: $this->product1, headers: $headers);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions(
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
             [
                 CURLOPT_HTTPHEADER => [
                     'X-Test-Header: test_value',
@@ -58,8 +59,7 @@ final class HttpTest extends BaseTestCase
                 ],
                 CURLOPT_POST => true,
                 CURLOPT_POSTFIELDS => json_encode($this->product1),
-            ],
-            $this->curlOptions[0]
+            ]
         );
     }
 
@@ -75,13 +75,13 @@ final class HttpTest extends BaseTestCase
 
         $response = $client->put(path: 'test/path', body: $this->product1, headers: $headers);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions(
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
             [
                 CURLOPT_HTTPHEADER => ['X-Test-Header: test_value'],
                 CURLOPT_CUSTOMREQUEST => "PUT",
                 CURLOPT_POSTFIELDS => json_encode($this->product1),
-            ],
-            $this->curlOptions[0]
+            ]
         );
     }
 
@@ -97,12 +97,12 @@ final class HttpTest extends BaseTestCase
 
         $response = $client->delete(path: 'test/path', headers: $headers);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions(
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
             [
                 CURLOPT_HTTPHEADER => ['X-Test-Header: test_value'],
                 CURLOPT_CUSTOMREQUEST => "DELETE",
-            ],
-            $this->curlOptions[0]
+            ]
         );
     }
 
@@ -118,12 +118,12 @@ final class HttpTest extends BaseTestCase
 
         $response = $client->post(path: 'test/path', body: $body);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions(
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
             [
                 CURLOPT_POST => true,
                 CURLOPT_POSTFIELDS => $body,
-            ],
-            $this->curlOptions[0]
+            ]
         );
     }
 
@@ -141,12 +141,12 @@ final class HttpTest extends BaseTestCase
 
         $response = $client->post(path: 'test/path', body: $this->product1, dataType: Http::DATA_TYPE_URL_ENCODED);
         $this->assertEquals($expectedResponse, $response);
-        $this->assertCurlOptions(
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
             [
                 CURLOPT_POST => true,
                 CURLOPT_POSTFIELDS => $body,
-            ],
-            $this->curlOptions[0]
+            ]
         );
     }
 
@@ -159,15 +159,15 @@ final class HttpTest extends BaseTestCase
         ]);
 
         $client->get(path: 'test/path');
-        $this->assertCurlOptions(
-            [CURLOPT_USERAGENT => "Shopify Admin API Library for PHP v{$version}"],
-            $this->curlOptions[0]
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
+            [CURLOPT_USERAGENT => "Shopify Admin API Library for PHP v{$version}"]
         );
 
         $client->get(path: 'test/path', headers: ['User-Agent' => "Extra user agent"]);
-        $this->assertCurlOptions(
-            [CURLOPT_USERAGENT => "Extra user agent | Shopify Admin API Library for PHP v{$version}"],
-            $this->curlOptions[1]
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
+            [CURLOPT_USERAGENT => "Extra user agent | Shopify Admin API Library for PHP v{$version}"]
         );
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The HTTP client tests were not ensuring that the URL that was effectively called was correct, which wasn't great.

### WHAT is this pull request doing?

Improving the tests to check the URL and to not have to tell the assertion method which call is being checked (it checks the 'next' one every time, so asserts just need to happen in the right order). That way, we decouple the tests with the implementation of the base test case.

The tests are still too tightly coupled with the curl calls, but it's very unlikely that that will ever change, so we should be fine for the foreseeable future.