### PR TITLE
Add Context user agent to HTTP requests

### DIFF
--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopify\Clients;
 
 use CurlHandle;
+use Shopify\Context;
 use Shopify\Exception\HttpRequestException;
 
 class Http
@@ -166,12 +167,18 @@ class Http
         }
 
         $version = require dirname(__FILE__) . '/../version.php';
-        $userAgent = "Shopify Admin API Library for PHP v{$version}";
+        $userAgentParts = ["Shopify Admin API Library for PHP v{$version}"];
+
+        if (Context::$USER_AGENT_PREFIX) {
+            array_unshift($userAgentParts, Context::$USER_AGENT_PREFIX);
+        }
+
         if (isset($headers['User-Agent'])) {
-            $userAgent = "{$headers['User-Agent']} | $userAgent";
+            array_unshift($userAgentParts, $headers['User-Agent']);
             unset($headers['User-Agent']);
         }
-        $this->setCurlOption($ch, CURLOPT_USERAGENT, $userAgent);
+
+        $this->setCurlOption($ch, CURLOPT_USERAGENT, implode(' | ', $userAgentParts));
 
         if ($body) {
             if (is_string($body)) {

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -6,6 +6,7 @@ namespace ShopifyTest\Clients;
 
 use Shopify\Clients\Http;
 use Shopify\Clients\HttpResponse;
+use Shopify\Context;
 use ShopifyTest\BaseTestCase;
 
 final class HttpTest extends BaseTestCase
@@ -156,6 +157,8 @@ final class HttpTest extends BaseTestCase
         $client = $this->getHttpClientWithMocks([
             $this->buildMockHttpResponse(200, $this->successResponse),
             $this->buildMockHttpResponse(200, $this->successResponse),
+            $this->buildMockHttpResponse(200, $this->successResponse),
+            $this->buildMockHttpResponse(200, $this->successResponse),
         ]);
 
         $client->get(path: 'test/path');
@@ -168,6 +171,20 @@ final class HttpTest extends BaseTestCase
         $this->assertHttpRequest(
             "{$this->domain}/test/path",
             [CURLOPT_USERAGENT => "Extra user agent | Shopify Admin API Library for PHP v{$version}"]
+        );
+
+        Context::$USER_AGENT_PREFIX = 'Test default user agent';
+
+        $client->get(path: 'test/path');
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
+            [CURLOPT_USERAGENT => "Test default user agent | Shopify Admin API Library for PHP v{$version}"]
+        );
+
+        $client->get(path: 'test/path', headers: ['User-Agent' => "Extra user agent"]);
+        $this->assertHttpRequest(
+            "{$this->domain}/test/path",
+            [CURLOPT_USERAGENT => "Extra user agent | Test default user agent | Shopify Admin API Library for PHP v{$version}"]
         );
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

We now have a `Context` class which holds some central values for the library. One of those values is an optional default user agent to be added to requests, which currently does nothing.

### WHAT is this pull request doing?

Start including the user agent value if it is set in `Context`.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [X] I have added/updated tests for this change
