### PR TITLE
Tweaking tests for coverage

### DIFF
--- a/tests/Auth/SessionTest.php
+++ b/tests/Auth/SessionTest.php
@@ -8,9 +8,6 @@ use DateTime;
 use Shopify\Auth\Session;
 use ShopifyTest\BaseTestCase;
 
-/**
- * @covers \Shopify\Auth\Session
- */
 final class SessionTest extends BaseTestCase
 {
     public function testSessionGetterAndSetterFunctions()
@@ -22,6 +19,7 @@ final class SessionTest extends BaseTestCase
         $session->setExpires('January 25, 2021');
         $session->setIsOnline(true);
         $session->setAccessToken('24ssdf243u2ohfd21');
+
         $this->assertEquals('12345', $session->getId());
         $this->assertEquals('my-shop.myshopify.com', $session->getShop());
         $this->assertEquals('asdf1234', $session->getState());

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -26,6 +26,10 @@ class BaseTestCase extends TestCase
             apiSecretKey: 'steffi',
             scopes: ['sleepy', 'kitty'],
             hostName: 'my-friends-cats',
+            apiVersion: 'unstable',
+            isEmbeddedApp: true,
+            isPrivateApp: false,
+            userAgentPrefix: '',
         );
         $this->requestDetails = [];
         $this->lastCheckedRequest = 0;

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -16,12 +16,19 @@ final class ContextTest extends BaseTestCase
             apiSecretKey: 'steffi',
             scopes: ['sleepy', 'kitty'],
             hostName: 'my-friends-cats',
+            isPrivateApp: false,
         );
 
         $this->assertEquals('ash', Context::$API_KEY);
         $this->assertEquals('steffi', Context::$API_SECRET_KEY);
         $this->assertEquals(['sleepy', 'kitty'], Context::$SCOPES);
         $this->assertEquals('my-friends-cats', Context::$HOST_NAME);
+
+        // This should not trigger the exception
+        Context::throwIfUninitialized();
+
+        // This should not trigger the exception
+        Context::throwIfPrivateApp('Not supposed to happen!');
     }
 
     // Context with different values has been set up in BaseTestCase


### PR DESCRIPTION
I'd previously made a few changes to ensure code coverage collection was working properly, and I left a `@covers` comment behind. I'm also tweaking the Context test to make sure we're getting 100% coverage on it.