### PR TITLE
Add Auth Scopes value object

### DIFF
--- a/src/Auth/Scopes.php
+++ b/src/Auth/Scopes.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Auth;
+
+final class Scopes
+{
+    public const SCOPE_DELIMITER = ',';
+
+    private array $compressedScopes;
+    private array $expandedScopes;
+
+    public function __construct(string | array $scopes)
+    {
+        if (is_string($scopes)) {
+            $scopesArray = explode(self::SCOPE_DELIMITER, $scopes);
+        } else {
+            $scopesArray = $scopes;
+        }
+
+        $scopesArray = array_unique(array_filter(array_map('trim', $scopesArray)));
+
+        $impliedScopes = $this->getImpliedScopes($scopesArray);
+
+        $this->compressedScopes = array_diff($scopesArray, $impliedScopes);
+        $this->expandedScopes = array_merge($scopesArray, $impliedScopes);
+    }
+
+    /**
+     * Converts the scopes in this object to a valid string.
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return implode(self::SCOPE_DELIMITER, $this->toArray());
+    }
+
+    /**
+     * Converts the scopes in this object to a valid array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->compressedScopes;
+    }
+
+    /**
+     * Checks whether the scopes in this object encapuslate the given scopes.
+     *
+     * @param string|array|Scopes $scopes The scopes to check
+     *
+     * @return bool
+     */
+    public function has(string | array | self $scopes): bool
+    {
+        if (!($scopes instanceof self)) {
+            $scopes = new self($scopes);
+        }
+
+        return count(array_diff($scopes->toArray(), $this->toArray())) === 0;
+    }
+
+    /**
+     * Checks whether the given scopes are equal to the scopes in this object.
+     *
+     * @param string|array|Scopes $scopes The scopes to check
+     *
+     * @return bool
+     */
+    public function equals(string | array | self $scopes): bool
+    {
+        if (!($scopes instanceof self)) {
+            $scopes = new self($scopes);
+        }
+
+        return (
+            count($this->compressedScopes) === count($scopes->compressedScopes) &&
+            count(array_diff($this->compressedScopes, $scopes->compressedScopes)) === 0
+        );
+    }
+
+    /**
+     * Returns any scopes that are implied by any of the given ones.
+     *
+     * @param array $scopes The scopes to check
+     *
+     * @return array
+     */
+    private function getImpliedScopes(array $scopes): array
+    {
+        $impliedScopes = [];
+        foreach ($scopes as $scope) {
+            if (preg_match('/^(unauthenticated_)?write_(.*)$/', $scope, $matches)) {
+                $impliedScopes[] = ($matches[1] ?? '') . "read_{$matches[2]}";
+            }
+        }
+
+        return $impliedScopes;
+    }
+}

--- a/src/Auth/Session.php
+++ b/src/Auth/Session.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopify\Auth;
 
 use DateTime;
+use Shopify\Context;
 
 /**
  * Stores App information from logged in merchants so they can make authenticated requests to the Admin API.
@@ -27,52 +28,52 @@ class Session
     ) {
     }
 
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    public function getShop()
+    public function getShop(): string
     {
         return $this->shop;
     }
 
-    public function getState()
+    public function getState(): string
     {
         return $this->state;
     }
 
-    public function getScope()
+    public function getScope(): string | null
     {
         return $this->scope;
     }
 
-    public function getExpires()
+    public function getExpires(): DateTime | null
     {
         return $this->expires;
     }
 
-    public function isOnline()
+    public function isOnline(): bool
     {
         return $this->isOnline;
     }
 
-    public function getAccessToken()
+    public function getAccessToken(): string | null
     {
         return $this->accessToken;
     }
 
-    public function getOnlineAccessInfo()
+    public function getOnlineAccessInfo(): AccessTokenOnlineUserInfo | null
     {
         return $this->onlineAccessInfo;
     }
 
-    public function setScope(string $scope)
+    public function setScope(string $scope): void
     {
-        return $this->scope = $scope;
+        $this->scope = $scope;
     }
 
-    public function setExpires(string | int | DateTime $expires)
+    public function setExpires(string | int | DateTime $expires): void
     {
         $date = null;
         if ($expires) {
@@ -84,17 +85,17 @@ class Session
                 $date = $expires;
             }
         }
-        return $this->expires = $date;
+        $this->expires = $date;
     }
 
-    public function setAccessToken(string $accessToken)
+    public function setAccessToken(string $accessToken): void
     {
-        return $this->accessToken = $accessToken;
+        $this->accessToken = $accessToken;
     }
 
-    public function setOnlineAccessInfo(AccessTokenOnlineUserInfo $onlineAccessInfo)
+    public function setOnlineAccessInfo(AccessTokenOnlineUserInfo $onlineAccessInfo): void
     {
-        return $this->onlineAccessInfo = $onlineAccessInfo;
+        $this->onlineAccessInfo = $onlineAccessInfo;
     }
 
     /**
@@ -118,5 +119,19 @@ class Session
         $newSession->onlineAccessInfo = $this->onlineAccessInfo;
 
         return $newSession;
+    }
+
+    /**
+     * Checks whether this session has all of the necessary settings to make requests to Shopify.
+     *
+     * @return bool
+     */
+    public function isValid(): bool
+    {
+        return (
+            Context::$SCOPES->equals($this->scope) &&
+            $this->accessToken &&
+            (!$this->expires || ($this->expires > new DateTime()))
+        );
     }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopify;
 
 use Shopify\Auth\SessionStorage;
+use Shopify\Auth\Scopes;
 use Shopify\Exception\MissingArgumentException;
 use Shopify\Exception\PrivateAppException;
 use Shopify\Exception\UninitializedContextException;
@@ -13,7 +14,7 @@ class Context
 {
     public static ?string $API_KEY = null;
     public static ?string $API_SECRET_KEY = null;
-    public static ?array $SCOPES = null;
+    public static Scopes $SCOPES;
     public static ?string $HOST_NAME = null;
     public static ?SessionStorage $SESSION_STORAGE = null;
     public static ?string $API_VERSION = null;
@@ -28,7 +29,7 @@ class Context
      *
      * @param string         $apiKey          App API key
      * @param string         $apiSecretKey    App API secret
-     * @param array          $scopes          App scopes
+     * @param string|array   $scopes          App scopes
      * @param string         $hostName        App host name
      * @param SessionStorage $sessionStorage  Session storage strategy
      * @param string         $apiVersion      App API key, defaults to unstable
@@ -39,7 +40,7 @@ class Context
     public static function initialize(
         string $apiKey,
         string $apiSecretKey,
-        array $scopes,
+        string | array $scopes,
         string $hostName,
         SessionStorage $sessionStorage,
         string $apiVersion = 'unstable',
@@ -47,6 +48,8 @@ class Context
         bool $isPrivateApp = false,
         string $userAgentPrefix = '',
     ): void {
+        $authScopes = new Scopes($scopes);
+
         // ensure required values given
         $requiredValues = [
             'apiKey' => $apiKey,
@@ -70,7 +73,7 @@ class Context
 
         self::$API_KEY = $apiKey;
         self::$API_SECRET_KEY = $apiSecretKey;
-        self::$SCOPES = $scopes;
+        self::$SCOPES = $authScopes;
         self::$HOST_NAME = $hostName;
         self::$SESSION_STORAGE = $sessionStorage;
         self::$API_VERSION = $apiVersion;

--- a/tests/Auth/ScopesTest.php
+++ b/tests/Auth/ScopesTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Auth;
+
+use Shopify\Auth\Scopes;
+use ShopifyTest\BaseTestCase;
+
+final class ScopesTest extends BaseTestCase
+{
+    public function testStringScopeParsing()
+    {
+        $scopeString = ' read_products, read_orders,read_orders , , write_customers ';
+        $scopes = new Scopes($scopeString);
+
+        $this->assertEquals('read_products,read_orders,write_customers', $scopes->toString());
+    }
+
+    public function testArrayScopeParsing()
+    {
+        $scopeArray = [' read_products', 'read_orders', 'read_orders', '', 'unauthenticated_write_customers '];
+        $scopes = new Scopes($scopeArray);
+
+        $this->assertEquals('read_products,read_orders,unauthenticated_write_customers', $scopes->toString());
+    }
+
+    public function testTrimsImpliedScopes()
+    {
+        $scopeString = 'read_customers,write_customers,read_products';
+        $scopes = new Scopes($scopeString);
+
+        $this->assertEquals('write_customers,read_products', $scopes->toString());
+    }
+
+    public function testTrimsImpliedUnauthenticatedScopes()
+    {
+        $scopeString = 'unauthenticated_read_customers,unauthenticated_write_customers,read_products';
+        $scopes = new Scopes($scopeString);
+
+        $this->assertEquals('unauthenticated_write_customers,read_products', $scopes->toString());
+    }
+
+    public function testHasReturnsTrueForStringSubset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has('write_customers'));
+    }
+
+    public function testHasReturnsTrueForArraySubset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(['write_customers']));
+    }
+
+    public function testHasReturnsTrueForObjectSubset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(new Scopes('write_customers')));
+    }
+
+    public function testHasReturnsTrueForEqualStrings()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has('read_products,write_customers'));
+    }
+
+    public function testHasReturnsTrueForEqualArrays()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(['read_products', 'write_customers']));
+    }
+
+    public function testHasReturnsTrueForEqualObjects()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(new Scopes('read_products,write_customers')));
+    }
+
+    public function testHasReturnsFalseForStringSuperset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertFalse($scopes->has('read_products,write_customers,read_orders'));
+    }
+
+    public function testHasReturnsFalseForArraySuperset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertFalse($scopes->has(['read_products', 'write_customers', 'read_orders']));
+    }
+
+    public function testHasReturnsFalseForObjectSuperset()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertFalse($scopes->has(new Scopes('read_products,write_customers,read_orders')));
+    }
+
+    public function testEqualsReturnsTrueForEqualScopes()
+    {
+        $scopes1 = new Scopes('write_customers,read_products');
+        $scopes2 = new Scopes(['write_customers', 'read_products']);
+        $this->assertTrue($scopes1->equals($scopes2));
+        $this->assertTrue($scopes2->equals($scopes1));
+    }
+
+    public function testEqualsReturnsFalseForDifferentScopes()
+    {
+        $scopes1 = new Scopes('write_customers,read_products');
+        $scopes2 = new Scopes(['write_customers', 'write_orders']);
+        $this->assertFalse($scopes1->equals($scopes2));
+        $this->assertFalse($scopes2->equals($scopes1));
+    }
+
+    public function testEqualsReturnsTrueForImpliedScopes()
+    {
+        $scopes1 = new Scopes('write_customers,read_products,write_products');
+        $scopes2 = new Scopes(['write_customers', 'write_products']);
+        $this->assertTrue($scopes1->equals($scopes2));
+        $this->assertTrue($scopes2->equals($scopes1));
+    }
+
+    public function testEqualsReturnsFalseForScopeSubsets()
+    {
+        $scopes1 = new Scopes('write_customers,read_products');
+        $scopes2 = new Scopes(['write_customers', 'read_products', 'write_orders']);
+        $this->assertFalse($scopes1->equals($scopes2));
+        $this->assertFalse($scopes2->equals($scopes1));
+    }
+
+    public function testEqualsAllowsStrings()
+    {
+        $scopes1 = new Scopes('write_customers,read_products');
+        $this->assertTrue($scopes1->equals('write_customers,read_products'));
+        $this->assertFalse($scopes1->equals('write_customers,read_products,write_products'));
+    }
+
+    public function testEqualsAllowsArrays()
+    {
+        $scopes1 = new Scopes('write_customers,read_products');
+        $this->assertTrue($scopes1->equals(['write_customers', 'read_products']));
+        $this->assertFalse($scopes1->equals(['write_customers', 'read_products', 'write_products']));
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShopifyTest;
 
+use Shopify\Auth\Scopes;
 use Shopify\Context;
 use ShopifyTest\Auth\MockSessionStorage;
 use ShopifyTest\BaseTestCase;
@@ -23,7 +24,7 @@ final class ContextTest extends BaseTestCase
 
         $this->assertEquals('ash', Context::$API_KEY);
         $this->assertEquals('steffi', Context::$API_SECRET_KEY);
-        $this->assertEquals(['sleepy', 'kitty'], Context::$SCOPES);
+        $this->assertEquals(new Scopes(['sleepy', 'kitty']), Context::$SCOPES);
         $this->assertEquals('my-friends-cats', Context::$HOST_NAME);
 
         // This should not trigger the exception
@@ -46,7 +47,7 @@ final class ContextTest extends BaseTestCase
 
         $this->assertEquals('tuck', Context::$API_KEY);
         $this->assertEquals('rocky', Context::$API_SECRET_KEY);
-        $this->assertEquals(['silly', 'doggo'], Context::$SCOPES);
+        $this->assertEquals(new Scopes(['silly', 'doggo']), Context::$SCOPES);
         $this->assertEquals('yay-for-doggos', Context::$HOST_NAME);
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The library should make it easy for apps to tell whether a session's scopes are up to date. To make that comparison more reliable, we should turn the scopes into a value object that allows one to check that with a single method call.

### WHAT is this pull request doing?

Adding the `Auth\Scopes` value object, which is now the type for `Context::$SCOPES`, and a `isActive` method to `Session` so it matches the funcionality from the Node library.

## Checklist

- [X] I have added/updated tests for this change