### PR TITLE
Ignore php.net in link checks

### DIFF
--- a/.github/workflows/markdown_link_checker_config.json
+++ b/.github/workflows/markdown_link_checker_config.json
@@ -1,6 +1,11 @@
 {
   "ignorePatterns": [
     {
+      "pattern": "^https?://php.net"
+    }
+  ],
+  "replacementPatterns": [
+    {
       "pattern": "^/",
       "replacement": "{{BASEURL}}/"
     }


### PR DESCRIPTION
We seem to be failing the link check for php.net on every run, so let's just start ignoring it.