### PR TITLE
Fix begin() method

### DIFF
--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -28,7 +28,7 @@ class OAuth
     /**
      * Initializes a session and cookie for the OAuth process, and returns the authorization url
      *
-     * @param string        $shop              A Shopify shop domain or hostname
+     * @param string        $shop              A Shopify domain name or hostname
      * @param string        $redirectPath      Redirect path for callback
      * @param bool          $isOnline          Whether or not the session is online
      * @param null|callable $setCookieFunction An optional override for setting cookie in response
@@ -48,6 +48,7 @@ class OAuth
         Context::throwIfUninitialized();
         Context::throwIfPrivateApp("OAuth is not allowed for private apps");
 
+        $shop = Utils::sanitizeShopDomain($shop);
         $mySessionId = $isOnline ? Uuid::uuid4()->toString() : $this->getOfflineSessionId($shop);
 
         $cookie = new OAuthCookie(

--- a/src/Auth/Session.php
+++ b/src/Auth/Session.php
@@ -6,6 +6,7 @@ namespace Shopify\Auth;
 
 use DateTime;
 use Shopify\Context;
+use Shopify\Utils;
 
 /**
  * Stores App information from logged in merchants so they can make authenticated requests to the Admin API.
@@ -26,6 +27,7 @@ class Session
         private string $state,
         // phpcs:enable
     ) {
+        $this->shop = Utils::sanitizeShopDomain($shop);
     }
 
     public function getId(): string

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -12,16 +12,16 @@ final class Utils
     /**
      * Returns a sanitized Shopify shop domain
      *
-     * If the provided shop domain is invalid or could not be sanitized, returns null.
+     * If the provided shop domain or hostname is invalid or could not be sanitized, returns null.
      *
-     * @param string $shopDomain A Shopify shop domain or hostname
+     * @param string $shop A Shopify shop domain or hostname
      * @param string|null $myshopifyDomain A custom Shopify domain
      *
-     * @return string $name a sanitifized Shopify shop domain, null if the provided domain is invalid
+     * @return string $name a sanitized Shopify shop domain, null if the provided domain is invalid
      */
-    public static function sanitizeShopDomain(string $shopDomain, ?string $myshopifyDomain = null)
+    public static function sanitizeShopDomain(string $shop, ?string $myshopifyDomain = null)
     {
-        $name = trim(strtolower($shopDomain));
+        $name = trim(strtolower($shop));
 
         $allowedDomainsRegexp = $myshopifyDomain ? "($myshopifyDomain)" : "(myshopify.com|myshopify.io)";
 

--- a/tests/Auth/OAuthTest.php
+++ b/tests/Auth/OAuthTest.php
@@ -326,7 +326,7 @@ final class OAuthTest extends BaseTestCase
         $oauth->begin('shopname', '/redirect', true);
     }
 
-    public function testBeginFunctionReturnSProperUrlForOfflineAccess()
+    public function testBeginFunctionReturnsProperUrlForOfflineAccess()
     {
         $oauth = new OAuth();
 
@@ -341,15 +341,15 @@ final class OAuthTest extends BaseTestCase
             }
         );
         $this->assertTrue($wasCallbackCalled);
-        $mySessionId = 'offline_shopname';
+        $mySessionId = 'offline_shopname.myshopify.com';
         $generatedState = Context::$SESSION_STORAGE->loadSession($mySessionId)->getState();
         $this->assertEquals(
-            "https://shopname/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=https%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=",
+            "https://shopname.myshopify.com/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=https%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=",
             $returnUrl
         );
     }
 
-    public function testBeginFunctionReturnSProperUrlForOnlineAccess()
+    public function testBeginFunctionReturnsProperUrlForOnlineAccess()
     {
         $oauth = new OAuth();
         $this->cookie = new OAuthCookie(
@@ -373,7 +373,7 @@ final class OAuthTest extends BaseTestCase
 
         $generatedState = Context::$SESSION_STORAGE->loadSession($testCookieId)->getState();
         $this->assertEquals(
-            "https://shopname/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=https%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=per-user",
+            "https://shopname.myshopify.com/admin/oauth/authorize?client_id=ash&scope=sleepy%2Ckitty&redirect_uri=https%3A%2F%2Fwww.my-friends-cats.com%2Fredirect&state={$generatedState}&grant_options%5B%5D=per-user",
             $returnUrl
         );
     }


### PR DESCRIPTION
### WHY are these changes introduced?

- I was working on documentation when I realized that `begin()` says it can take it a shop name but it actually doesn't. For example, you can see in the tests that it was actually redirecting to `https://shopname/admin/oauth/authorize?key=value` instead of `https://shopname.myshopify.com/admin/oauth/authorize?key=value`

### WHAT is this pull request doing?
- apply the `sanitizeShopDomain` function from Utils to the passed in `$shop` parameter in `OAuth::begin()`
- fix my own spelling mistakes LOL
- change the name of the `$shopDomain` parameter in `sanitizeShopDomain` to just `$shop` since we can take in domains and hostnames
- automatically call the `sanitizeShopDomain` function in `Session` when an instance is initialized. This will avoid multiple duplicate calls to `Utils::sanitizeShopDomain` in the future. This also removes ambiguity in the future (we know the session shop string is always a domain name)

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)


## Checklist

- [x] I have added/updated tests for this change

