### PR TITLE
Add Rest client pagination

### DIFF
--- a/src/Clients/PageInfo.php
+++ b/src/Clients/PageInfo.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Clients;
+
+class PageInfo
+{
+    private const LINK_HEADER_REGEXP = '/<([^<]+)>; rel="([^"]+)"/';
+
+    /**
+     * PageInfo constructor.
+     *
+     * @param array|null  $fields          list of which fields to show in the results.
+     *                                     This parameter only works for some endpoints.
+     * @param string|null $previousPageUrl link to previous page of the result
+     * @param string|null $nextPageUrl     link to the next page of the result
+     */
+    public function __construct(
+        private ?array $fields,
+        private ?string $previousPageUrl,
+        private ?string $nextPageUrl,
+    ) {
+    }
+
+    /**
+     * When you send a request to a REST endpoint that supports cursor-based pagination, the response body returns the
+     * first page of results, and a response header returns links to the next page and the previous page of results
+     * (if applicable). You can use the links in the response header to iterate through the pages of results.
+     *
+     * @param string $linkHeader Pagination link header
+     *
+     * @return \Shopify\Clients\PageInfo
+     */
+    public static function fromLinkHeader(string $linkHeader): PageInfo
+    {
+        $linkHeaderSegments = explode(', ', $linkHeader);
+
+        $fields = self::parseFields($linkHeaderSegments);
+
+        list($previousUrl, $nextUrl) = self::parseUrls($linkHeaderSegments);
+
+        return new PageInfo($fields, $previousUrl, $nextUrl);
+    }
+
+    /**
+     * @param array $linkHeaderSegments Link header segments
+     *
+     * @return array
+     */
+    private static function parseFields(array $linkHeaderSegments): array
+    {
+        $fields = [];
+        foreach ($linkHeaderSegments as $segment) {
+            $parsedUrl = [];
+            preg_match(self::LINK_HEADER_REGEXP, $segment, $parsedUrl);
+            $linkUrl = $parsedUrl[1];
+            $queryParams = self::getQueryFromUrl($linkUrl);
+
+            if (array_key_exists('fields', $queryParams)) {
+                $linkFields = $queryParams['fields'];
+                $fields = explode(',', $linkFields);
+            }
+        }
+        return $fields;
+    }
+
+    /**
+     * @param array $linkHeaderSegments Link header segments
+     *
+     * @return array
+     */
+    private static function parseUrls(array $linkHeaderSegments): array
+    {
+        $previousUrl = null;
+        $nextUrl = null;
+        foreach ($linkHeaderSegments as $url) {
+            $parsedLink = [];
+            preg_match(self::LINK_HEADER_REGEXP, $url, $parsedLink);
+            $linkRel = $parsedLink[2];
+            $linkUrl = $parsedLink[1];
+
+            switch ($linkRel) {
+                case 'previous':
+                    $previousUrl = $linkUrl;
+                    break;
+                case 'next':
+                    $nextUrl = $linkUrl;
+                    break;
+            }
+        }
+        return array($previousUrl, $nextUrl);
+    }
+
+    /**
+     * @return string|null Url of the previous page or null if there is no more pages
+     */
+    public function getPreviousPageUrl(): ?string
+    {
+        return $this->previousPageUrl;
+    }
+
+    /**
+     * @return string|null  Url of the next page or null if there is no more pages
+     */
+    public function getNextPageUrl(): ?string
+    {
+        return $this->nextPageUrl;
+    }
+
+    /**
+     * @return array|null list of which fields to show in the results. This parameter only works for some endpoints.
+     */
+    public function getFields(): ?array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * <code>
+     *  $client->get(path: 'products', query: $response->getPageInfo()->getPreviousPageQuery());
+     * </code>
+     *
+     * @return array Query to get the previous page
+     */
+    public function getPreviousPageQuery(): array
+    {
+        return self::getQueryFromUrl($this->getPreviousPageUrl());
+    }
+
+    /**
+     * <code>
+     *  $client->get(path: 'products', query: $response->getPageInfo()->getNextPageQuery());
+     * </code>
+     *
+     * @return array Query to get the next page
+     */
+    public function getNextPageQuery(): array
+    {
+        return self::getQueryFromUrl($this->getNextPageUrl());
+    }
+
+    /**
+     * @return bool false if there is no more pages
+     */
+    public function hasNextPage(): bool
+    {
+        return $this->getNextPageUrl() !== null;
+    }
+
+    /**
+     * @return bool false if there is no more pages
+     */
+    public function hasPreviousPage(): bool
+    {
+        return self::getPreviousPageUrl() !== null;
+    }
+
+    private static function getQueryFromUrl(string $url): array
+    {
+        $queryParams = [];
+        parse_str(parse_url($url, PHP_URL_QUERY), $queryParams);
+        return $queryParams;
+    }
+}

--- a/src/Clients/RestResponse.php
+++ b/src/Clients/RestResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Shopify\Clients;
+
+class RestResponse extends HttpResponse
+{
+
+    /**
+     * RestResponse constructor.
+     *
+     * @param int                            $statusCode
+     * @param array                          $headers
+     * @param array|string|null              $body
+     * @param \Shopify\Clients\PageInfo|null $pageInfo
+     */
+    public function __construct(
+        int $statusCode,
+        array $headers = [],
+        array|string|null $body = null,
+        private PageInfo|null $pageInfo = null
+    ) {
+        parent::__construct($statusCode, $headers, $body);
+    }
+
+    /**
+     * @return \Shopify\Clients\PageInfo|null Pagination Information
+     */
+    public function getPageInfo(): ?PageInfo
+    {
+        return $this->pageInfo;
+    }
+}

--- a/tests/Clients/PageInfoTest.php
+++ b/tests/Clients/PageInfoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ShopifyTest\Clients;
+
+use Shopify\Clients\PageInfo;
+use ShopifyTest\BaseTestCase;
+
+class PageInfoTest extends BaseTestCase
+{
+    use PaginationTestHelper;
+
+    public function testParsePreviousAndNextUrlsFromLinkHeaderAndFields()
+    {
+        $link = $this->getProductsLinkHeader(previousToken: 'previousToken', nextToken: 'nextToken');
+
+        $pageInfo = PageInfo::fromLinkHeader($link);
+
+        $this->assertEquals(
+            new PageInfo(
+                ['test1', 'test2'],
+                $this->getProductsAdminApiPaginationUrl("previousToken"),
+                $this->getProductsAdminApiPaginationUrl("nextToken")
+            ),
+            $pageInfo
+        );
+    }
+
+    public function testPreviousAndNextPageQueries()
+    {
+        $pageInfo = new PageInfo(
+            ['test1', 'test2'],
+            $this->getProductsAdminApiPaginationUrl("previousToken"),
+            $this->getProductsAdminApiPaginationUrl("nextToken")
+        );
+
+        $this->assertEquals(
+            ["limit" => "10", "fields" => 'test1,test2', 'page_info' => 'previousToken'],
+            $pageInfo->getPreviousPageQuery()
+        );
+        $this->assertEquals(
+            ["limit" => "10", "fields" => 'test1,test2', 'page_info' => 'nextToken'],
+            $pageInfo->getNextPageQuery()
+        );
+    }
+}

--- a/tests/Clients/PaginationTestHelper.php
+++ b/tests/Clients/PaginationTestHelper.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ShopifyTest\Clients;
+
+use Shopify\Context;
+
+trait PaginationTestHelper
+{
+    protected string $domain = 'test-shop.myshopify.io';
+
+    /**
+     * @param string $path Rest resource. e.g. `products`
+     * @param string $queryString Query string `e.g. "limit=10&fields=test1%2Ctest2"`
+     *
+     * @return string
+     */
+    protected function getAdminApiUrl(string $path, string $queryString): string
+    {
+        return "https://$this->domain/admin/api/" . Context::$API_VERSION . "/$path.json?$queryString";
+    }
+
+    /**
+     * Products URL link headers with fields: `limit=10&fields=test1%2Ctest2` and appends the token
+     * @param string|null $previousToken A unique ID used to access previous page
+     * @param string|null $nextToken A unique ID used to access next page
+     *
+     * @return string
+     */
+    protected function getProductsLinkHeader(?string $previousToken = null, ?string $nextToken = null): string
+    {
+        $headers = [];
+        if ($previousToken) {
+            $previousPageUrl = $this->getProductsAdminApiPaginationUrl($previousToken);
+            array_push($headers, "<$previousPageUrl>; rel=\"previous\"");
+        }
+        if ($nextToken) {
+            $nextPageUrl = $this->getProductsAdminApiPaginationUrl($nextToken);
+            array_push($headers, "<$nextPageUrl>; rel=\"next\"");
+        }
+        return (implode(', ', $headers));
+    }
+
+    /**
+     * Products next or previous page URL with fields: `limit=10&fields=test1%2Ctest2` and appends the token
+     * @param string $token  A unique ID used to access previous or next page
+     *
+     * @return string
+     */
+    protected function getProductsAdminApiPaginationUrl(string $token): string
+    {
+        return "https://$this->domain/admin/api/"
+            . Context::$API_VERSION
+            . "/products.json?limit=10&fields=test1%2Ctest2&page_info=$token";
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Parsing pagination headers

### WHAT is this pull request doing?

- Add functionality to access previous and next page headers if they exist

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
