### PR TITLE
Refactor tests to use a single request mock method

### DIFF
--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -236,6 +236,7 @@ class Http
                     $responseBody = json_decode($body, true);
                     break;
                 case self::DATA_TYPE_URL_ENCODED:
+                    $responseBody = [];
                     parse_str($body, $responseBody);
                     break;
             }

--- a/tests/Auth/OAuthTest.php
+++ b/tests/Auth/OAuthTest.php
@@ -9,10 +9,18 @@ use Shopify\Auth\Session;
 use Shopify\Auth\AccessTokenOnlineUserInfo;
 use Shopify\Context;
 use ShopifyTest\BaseTestCase;
+use ShopifyTest\Clients\MockRequest;
 
 final class OAuthTest extends BaseTestCase
 {
     private string $oauthSessionId = 'test_oauth_session';
+
+    private array $codeRequestBody = [
+        'client_id' => 'ash',
+        'client_secret' => 'steffi',
+        'code' => 'real_code',
+    ];
+
     private array $onlineResponse = [
         'access_token' => 'some access token',
         'scope' => 'read_products',
@@ -29,36 +37,31 @@ final class OAuthTest extends BaseTestCase
             'collaborator' => true,
         ],
     ];
+
     private array $offlineResponse = [
         'access_token' => 'some access token',
         'scope' => 'read_products',
     ];
-
 
     /**
      * @dataProvider validCallbackProvider
      */
     public function testValidCallback($isOnline, $isEmbedded)
     {
-
         Context::$IS_EMBEDDED_APP = $isEmbedded;
 
         $this->createTestSession($isOnline);
 
-        $body = '{"client_id":"ash","client_secret":"steffi","code":"real_code"}';
-        $bodyLength = strlen($body);
-
-        $this->mockTransportWithExpectations(
-            url: "https://test-shop.myshopify.io/admin/oauth/access_token",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['Content-Type: application/json',
-                "Content-Length: $bodyLength"
-            ],
-            response: $this->buildMockHttpResponse(200, $isOnline ? $this->onlineResponse : $this->offlineResponse),
-            body: $body
-        );
-
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://test-shop.myshopify.io/admin/oauth/access_token",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v",
+                headers: ['Content-Type: application/json'],
+                body: json_encode($this->codeRequestBody),
+                response: $this->buildMockHttpResponse(200, $isOnline ? $this->onlineResponse : $this->offlineResponse),
+            ),
+        ]);
 
         $mockCookies = [OAuth::SESSION_ID_COOKIE_NAME => $this->oauthSessionId];
         $mockQuery = [
@@ -257,19 +260,16 @@ final class OAuthTest extends BaseTestCase
 
         $this->createTestSession(true);
 
-        $body = '{"client_id":"ash","client_secret":"steffi","code":"real_code"}';
-        $bodyLength = strlen($body);
-
-        $this->mockTransportWithExpectations(
-            url: "https://test-shop.myshopify.io/admin/oauth/access_token",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['Content-Type: application/json',
-                "Content-Length: $bodyLength"
-            ],
-            response: $this->buildMockHttpResponse(200, $this->onlineResponse),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://test-shop.myshopify.io/admin/oauth/access_token",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v",
+                headers: ['Content-Type: application/json'],
+                body: json_encode($this->codeRequestBody),
+                response: $this->buildMockHttpResponse(200, $this->onlineResponse),
+            ),
+        ]);
 
         $mockCookies = [OAuth::SESSION_ID_COOKIE_NAME => $this->oauthSessionId];
         $mockQuery = [
@@ -293,19 +293,16 @@ final class OAuthTest extends BaseTestCase
 
         $this->createTestSession(true);
 
-        $body = '{"client_id":"ash","client_secret":"steffi","code":"real_code"}';
-        $bodyLength = strlen($body);
-
-        $this->mockTransportWithExpectations(
-            url: "https://test-shop.myshopify.io/admin/oauth/access_token",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['Content-Type: application/json',
-                "Content-Length: $bodyLength"
-            ],
-            response: $this->buildMockHttpResponse(200, $this->onlineResponse),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://test-shop.myshopify.io/admin/oauth/access_token",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v",
+                headers: ['Content-Type: application/json'],
+                body: json_encode($this->codeRequestBody),
+                response: $this->buildMockHttpResponse(200, $this->onlineResponse),
+            ),
+        ]);
 
         $mockCookies = [OAuth::SESSION_ID_COOKIE_NAME => $this->oauthSessionId];
         $mockQuery = [
@@ -325,19 +322,16 @@ final class OAuthTest extends BaseTestCase
     {
         $this->createTestSession(false);
 
-        $body = '{"client_id":"ash","client_secret":"steffi","code":"real_code"}';
-        $bodyLength = strlen($body);
-
-        $this->mockTransportWithExpectations(
-            url: "https://test-shop.myshopify.io/admin/oauth/access_token",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['Content-Type: application/json',
-                "Content-Length: $bodyLength"
-            ],
-            response: $this->buildMockHttpResponse(500, ''),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://test-shop.myshopify.io/admin/oauth/access_token",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v",
+                headers: ['Content-Type: application/json'],
+                body: json_encode($this->codeRequestBody),
+                response: $this->buildMockHttpResponse(500, ''),
+            ),
+        ]);
 
         $mockCookies = [OAuth::SESSION_ID_COOKIE_NAME => $this->oauthSessionId];
         $mockQuery = [

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -25,13 +25,16 @@ final class HttpTest extends BaseTestCase
     public function testGetRequestWithoutQuery()
     {
         $headers = ['X-Test-Header' => 'test_value'];
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Test-Header: test_value'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: ['X-Test-Header: test_value'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
@@ -42,13 +45,16 @@ final class HttpTest extends BaseTestCase
     public function testGetRequest()
     {
         $headers = ['X-Test-Header' => 'test_value'];
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path?path=some_path",
-            method: "GET",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Test-Header: test_value'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path?path=some_path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: ['X-Test-Header: test_value'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
@@ -63,18 +69,21 @@ final class HttpTest extends BaseTestCase
         $body = json_encode($this->product1);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path?path=some_path",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength",
-                     'X-Test-Header: test_value'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path?path=some_path",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                    'X-Test-Header: test_value',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -97,18 +106,21 @@ final class HttpTest extends BaseTestCase
         $body = json_encode($this->product1);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path?path=some_path",
-            method: "PUT",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength",
-                     'X-Test-Header: test_value'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path?path=some_path",
+                method: "PUT",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                    'X-Test-Header: test_value',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -127,13 +139,16 @@ final class HttpTest extends BaseTestCase
     {
         $headers = ['X-Test-Header' => 'test_value'];
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path?path=some_path",
-            method: "DELETE",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Test-Header: test_value'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path?path=some_path",
+                method: "DELETE",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: ['X-Test-Header: test_value'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -148,17 +163,20 @@ final class HttpTest extends BaseTestCase
         $body = json_encode($this->product1);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength"
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -175,17 +193,24 @@ final class HttpTest extends BaseTestCase
 
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "POST",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/x-www-form-urlencoded',
-                     "Content-Length: $bodyLength"
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse, dataType: Http::DATA_TYPE_URL_ENCODED),
-            body: $body
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "POST",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    "Content-Length: $bodyLength",
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(
+                    200,
+                    $this->successResponse,
+                    dataType: Http::DATA_TYPE_URL_ENCODED,
+                ),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -198,85 +223,100 @@ final class HttpTest extends BaseTestCase
 
     public function testUserAgent()
     {
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client = new Http($this->domain);
-
         $client->get(path: 'test/path');
 
-
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Extra user agent | Shopify Admin API Library for PHP v$this->version",
-            headers: [],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
-
-        $client = new Http($this->domain);
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Extra user agent | Shopify Admin API Library for PHP v$this->version$",
+                headers: [],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client->get(path: 'test/path', headers: ['User-Agent' => "Extra user agent"]);
 
         Context::$USER_AGENT_PREFIX = 'Test default user agent';
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Test default user agent | Shopify Admin API Library for PHP v$this->version",
-            headers: [],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
-        $client = new Http($this->domain);
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Test default user agent | Shopify Admin API Library for PHP v$this->version$",
+                headers: [],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client->get(path: 'test/path');
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Extra user agent | Test default user agent | Shopify Admin API Library for PHP v$this->version",
-            headers: [],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
-        $client = new Http($this->domain);
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                // phpcs:ignore
+                userAgent: "^Extra user agent | Test default user agent | Shopify Admin API Library for PHP v$this->version$",
+                headers: [],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $client->get(path: 'test/path', headers: ['User-Agent' => "Extra user agent"]);
     }
 
     public function testRequestThrowsErrorOnCurlFailure()
     {
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/test/path",
-            method: "GET",
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [],
-            response: $this->buildMockHttpResponse(),
-            error: 'Test error!'
-        );
-        $client = new Http($this->domain);
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                headers: [],
+                response: $this->buildMockHttpResponse(),
+                error: 'Test error!',
+                allowOtherHeaders: false,
+            ),
+        ]);
 
+        $client = new Http($this->domain);
         $this->expectException('\Shopify\Exception\HttpRequestException');
         $client->get(path: 'test/path');
     }
 
     public function testRetryLogicForAllRetriableCodes()
     {
-        $this->mockTransportWithExpectationsWithoutBodyWithMultipleResponses(
-            "https://$this->domain/test/path",
-            "GET",
-            "Shopify Admin API Library for PHP v$this->version",
-            [],
-            [
-                $this->buildMockHttpResponse(429, headers: ['Retry-After' => 0]),
-                $this->buildMockHttpResponse(500),
-                $this->buildMockHttpResponse(200, $this->successResponse),
-            ]
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                response: $this->buildMockHttpResponse(429, headers: ['Retry-After' => 0]),
+            ),
+            new MockRequest(
+                response: $this->buildMockHttpResponse(500),
+                isRetry: true,
+            ),
+            new MockRequest(
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                isRetry: true,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -288,17 +328,22 @@ final class HttpTest extends BaseTestCase
 
     public function testRetryStopsAfterReachingTheLimit()
     {
-        $this->mockTransportWithExpectationsWithoutBodyWithMultipleResponses(
-            "https://$this->domain/test/path",
-            "GET",
-            "Shopify Admin API Library for PHP v$this->version",
-            [],
-            [
-                $this->buildMockHttpResponse(500),
-                $this->buildMockHttpResponse(500),
-                $this->buildMockHttpResponse(500, headers: ['X-Is-Last-Test-Request' => true]),
-            ]
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                response: $this->buildMockHttpResponse(500),
+            ),
+            new MockRequest(
+                response: $this->buildMockHttpResponse(500),
+                isRetry: true,
+            ),
+            new MockRequest(
+                response: $this->buildMockHttpResponse(500, headers: ['X-Is-Last-Test-Request' => true]),
+                isRetry: true,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 
@@ -310,16 +355,18 @@ final class HttpTest extends BaseTestCase
 
     public function testRetryStopsOnNonRetriableError()
     {
-        $this->mockTransportWithExpectationsWithoutBodyWithMultipleResponses(
-            "https://$this->domain/test/path",
-            "GET",
-            "Shopify Admin API Library for PHP v$this->version",
-            [],
-            [
-                $this->buildMockHttpResponse(500),
-                $this->buildMockHttpResponse(400, headers: ['X-Is-Last-Test-Request' => true]),
-            ]
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/test/path",
+                method: "GET",
+                userAgent: "^Shopify Admin API Library for PHP v$this->version$",
+                response: $this->buildMockHttpResponse(500),
+            ),
+            new MockRequest(
+                response: $this->buildMockHttpResponse(400, headers: ['X-Is-Last-Test-Request' => true]),
+                isRetry: true,
+            ),
+        ]);
 
         $client = new Http($this->domain);
 

--- a/tests/Clients/MockRequest.php
+++ b/tests/Clients/MockRequest.php
@@ -8,14 +8,15 @@ final class MockRequest
 {
     public function __construct(
         // phpcs:disable
-        public string $url,
-        public string $method,
-        public string $userAgent,
-        public array $headers,
         public array $response,
+        public ?string $url = null,
+        public ?string $method = null,
+        public ?string $userAgent = null,
+        public array $headers = [],
         public ?string $body = null,
         public ?string $error = null,
         public bool $allowOtherHeaders = true,
+        public bool $isRetry = false,
         // phpcs:enable
     ) {
     }

--- a/tests/Clients/RestTest.php
+++ b/tests/Clients/RestTest.php
@@ -43,13 +43,16 @@ class RestTest extends BaseTestCase
 
         $client = new Rest($this->domain, 'dummy-token');
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
-            method: 'GET',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ["X-Test-Header: test_value", "X-Shopify-Access-Token: " . Context::$API_SECRET_KEY],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
+                method: 'GET',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: ["X-Test-Header: test_value", "X-Shopify-Access-Token: " . Context::$API_SECRET_KEY],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -64,13 +67,16 @@ class RestTest extends BaseTestCase
 
         $client = new Rest($this->domain, 'dummy-token');
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
-            method: 'GET',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Test-Header: test_value', 'X-Shopify-Access-Token: dummy-token'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
+                method: 'GET',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: ['X-Test-Header: test_value', 'X-Shopify-Access-Token: dummy-token'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -83,13 +89,16 @@ class RestTest extends BaseTestCase
     {
         $client = new Rest($this->domain, 'dummy-token');
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
-            method: 'GET',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Shopify-Access-Token: dummy-token'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
+                method: 'GET',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: ['X-Shopify-Access-Token: dummy-token'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -110,19 +119,21 @@ class RestTest extends BaseTestCase
         $body = json_encode($postData);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
-            method: 'POST',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength",
-                     'X-Shopify-Access-Token: dummy-token'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
-
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
+                method: 'POST',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                    'X-Shopify-Access-Token: dummy-token',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -143,19 +154,21 @@ class RestTest extends BaseTestCase
         $body = json_encode($postData);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
-            method: 'POST',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength",
-                     'X-Shopify-Access-Token: dummy-token'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
-
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
+                method: 'POST',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                    'X-Shopify-Access-Token: dummy-token',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -180,19 +193,26 @@ class RestTest extends BaseTestCase
 
         $body = http_build_query($postData);
         $bodyLength = strlen($body);
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
-            method: 'POST',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/x-www-form-urlencoded',
-                     "Content-Length: $bodyLength",
-                     'X-Shopify-Access-Token: dummy-token'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse, dataType: Http::DATA_TYPE_URL_ENCODED),
-            body: $body
-        );
 
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json",
+                method: 'POST',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    "Content-Length: $bodyLength",
+                    'X-Shopify-Access-Token: dummy-token',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(
+                    200,
+                    $this->successResponse,
+                    dataType: Http::DATA_TYPE_URL_ENCODED,
+                ),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -213,19 +233,21 @@ class RestTest extends BaseTestCase
         $body = json_encode($postData);
         $bodyLength = strlen($body);
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products/123.json?path=some_path",
-            method: 'PUT',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: [
-                     'Content-Type: application/json',
-                     "Content-Length: $bodyLength",
-                     'X-Shopify-Access-Token: dummy-token'
-                 ],
-            response: $this->buildMockHttpResponse(200, $this->successResponse),
-            body: $body
-        );
-
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products/123.json?path=some_path",
+                method: 'PUT',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: [
+                    'Content-Type: application/json',
+                    "Content-Length: $bodyLength",
+                    'X-Shopify-Access-Token: dummy-token',
+                ],
+                body: $body,
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
@@ -245,13 +267,16 @@ class RestTest extends BaseTestCase
 
         $client = new Rest($this->domain, 'dummy-token');
 
-        $this->mockTransportWithExpectations(
-            url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
-            method: 'DELETE',
-            userAgent: "Shopify Admin API Library for PHP v$this->version",
-            headers: ['X-Test-Header: test_value', 'X-Shopify-Access-Token: dummy-token'],
-            response: $this->buildMockHttpResponse(200, $this->successResponse)
-        );
+        $this->mockTransportRequests([
+            new MockRequest(
+                url: "https://$this->domain/admin/api/" . Context::$API_VERSION . "/products.json?path=some_path",
+                method: 'DELETE',
+                userAgent: "Shopify Admin API Library for PHP v$this->version",
+                headers: ['X-Test-Header: test_value', 'X-Shopify-Access-Token: dummy-token'],
+                response: $this->buildMockHttpResponse(200, $this->successResponse),
+                allowOtherHeaders: false,
+            ),
+        ]);
 
         $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 


### PR DESCRIPTION
### WHY are these changes introduced?

@MuhammadFarag added some very useful methods for mocking HTTP requests as part of the refactoring. This is just taking that one step further by joining the logic of those methods in a single, one-stop-shop method for mocking HTTP requests.

### WHAT is this pull request doing?

Refactoring the previous usages of the separate mocking methods so we only need to maintain one method, and removing the old methods.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have updated the documentation for public APIs from the library (if applicable)
