### PR TITLE
Fix auth scope has check

### DIFF
--- a/src/Auth/Scopes.php
+++ b/src/Auth/Scopes.php
@@ -60,7 +60,7 @@ final class Scopes
             $scopes = new self($scopes);
         }
 
-        return count(array_diff($scopes->toArray(), $this->toArray())) === 0;
+        return count(array_diff($scopes->toArray(), $this->expandedScopes)) === 0;
     }
 
     /**

--- a/tests/Auth/ScopesTest.php
+++ b/tests/Auth/ScopesTest.php
@@ -95,6 +95,27 @@ final class ScopesTest extends BaseTestCase
         $this->assertFalse($scopes->has(new Scopes('read_products,write_customers,read_orders')));
     }
 
+    public function testHasReturnsTrueForImpliedObjectScope()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(new Scopes('read_products,read_customers')));
+        $this->assertFalse($scopes->has(new Scopes('write_products,write_customers')));
+    }
+
+    public function testHasReturnsTrueForImpliedArrayScope()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has(['read_products', 'read_customers']));
+        $this->assertFalse($scopes->has(['write_products', 'write_customers']));
+    }
+
+    public function testHasReturnsTrueForImpliedStringScope()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->has('read_products,read_customers'));
+        $this->assertFalse($scopes->has('write_products,write_customers'));
+    }
+
     public function testEqualsReturnsTrueForEqualScopes()
     {
         $scopes1 = new Scopes('write_customers,read_products');
@@ -139,5 +160,38 @@ final class ScopesTest extends BaseTestCase
         $scopes1 = new Scopes('write_customers,read_products');
         $this->assertTrue($scopes1->equals(['write_customers', 'read_products']));
         $this->assertFalse($scopes1->equals(['write_customers', 'read_products', 'write_products']));
+    }
+
+    public function testEqualsReturnsTrueForImpliedObjectScopes()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+
+        $scopes2 = new Scopes('read_products,read_customers,write_customers');
+        $this->assertTrue($scopes->equals($scopes2));
+        $this->assertTrue($scopes2->equals($scopes));
+
+        $scopes2 = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->equals($scopes2));
+        $this->assertTrue($scopes2->equals($scopes));
+
+        $scopes2 = new Scopes('write_products,read_customers,write_customers');
+        $this->assertFalse($scopes->equals($scopes2));
+        $this->assertFalse($scopes2->equals($scopes));
+    }
+
+    public function testEqualsReturnsTrueForImpliedArrayScopes()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->equals(['read_products', 'read_customers', 'write_customers']));
+        $this->assertTrue($scopes->equals(['read_products', 'write_customers']));
+        $this->assertFalse($scopes->equals(['write_products', 'read_customers', 'write_customers']));
+    }
+
+    public function testEqualsReturnsTrueForImpliedStringScopes()
+    {
+        $scopes = new Scopes('read_products,write_customers');
+        $this->assertTrue($scopes->equals('read_products,read_customers,write_customers'));
+        $this->assertTrue($scopes->equals('read_products,write_customers'));
+        $this->assertFalse($scopes->equals('write_products,read_customers,write_customers'));
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We had an issue in our `Auth\Scopes::has` method, which was not returning true if we checked if an app has an implied scope.

### WHAT is this pull request doing?

Comparing against the expanded set of scopes when checking if a Scopes object `has` a certain set of scopes, rather than the compressed set, so we can also check if implied scopes are contained.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
