### PR TITLE
Add HttpHeaders object

### DIFF
--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -17,8 +17,6 @@ class Http
     public const DATA_TYPE_URL_ENCODED = 'application/x-www-form-urlencoded';
     public const DATA_TYPE_GRAPHQL = 'application/graphql';
 
-    public const X_SHOPIFY_ACCESS_TOKEN = "X-Shopify-Access-Token";
-
     private const RETRIABLE_STATUS_CODES = [429, 500];
 
     public function __construct(private string $domain)

--- a/src/Clients/HttpHeaders.php
+++ b/src/Clients/HttpHeaders.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Clients;
+
+/**
+ * Value object used to represent a set of HTTP headers received in a request.
+ */
+final class HttpHeaders
+{
+    public const X_SHOPIFY_ACCESS_TOKEN = "X-Shopify-Access-Token";
+
+    private array $headerSet = [];
+
+    /**
+     * Loads a set of HTTP headers.
+     *
+     * @param array $headers HTTP request headers, from which the set will be loaded. This must be a hash of
+     *                       header => value pairs. Value will be forcibly cast to string so objects that implement
+     *                       toString are also valid.
+     */
+    public function __construct(array $headers)
+    {
+        $this->normalizeAndLoadHeaders($headers);
+    }
+
+    /**
+     * Checks if this set contains the given header.
+     *
+     * @param string $header The header to check
+     *
+     * @return bool
+     */
+    public function has(string $header): bool
+    {
+        list($header) = $this->normalizeHeader($header);
+        return array_key_exists($header, $this->headerSet);
+    }
+
+    /**
+     * Fetches the given header, returning null if it does not exist.
+     *
+     * @param string $header The header to fetch
+     *
+     * @return string|null
+     */
+    public function get(string $header): string | null
+    {
+        if (!$this->has($header)) {
+            return null;
+        }
+
+        list($header) = $this->normalizeHeader($header);
+        return $this->headerSet[$header];
+    }
+
+    /**
+     * Returns the set of normalized headers as an array of header => value pairs.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->headerSet;
+    }
+
+    /**
+     * Normalizes and then loads the given set of headers, to make sure we're always working with a consistent object.
+     *
+     * @param array $headers The headers to load
+     */
+    private function normalizeAndLoadHeaders(array $headers): void
+    {
+        $this->headerSet = [];
+        foreach ($headers as $header => $value) {
+            list($header, $value) = $this->normalizeHeader($header, $value);
+            $this->headerSet[$header] = $value;
+        }
+    }
+
+    /**
+     * Normalizes a single header and its value, ensuring that they are both stored in a consistent format.
+     *
+     * @param string $header The header name
+     * @param mixed  $value  The header's value
+     *
+     * @return array Normalized header in format [$header, $value]
+     */
+    private function normalizeHeader(string $header, mixed $value = null): array
+    {
+        return [strtolower($header), $value ? (string)$value : null];
+    }
+}

--- a/src/Clients/Rest.php
+++ b/src/Clients/Rest.php
@@ -38,7 +38,7 @@ class Rest extends Http
         ?int $tries = null,
         array $query = []
     ): HttpResponse {
-        $headers[self::X_SHOPIFY_ACCESS_TOKEN] =
+        $headers[HttpHeaders::X_SHOPIFY_ACCESS_TOKEN] =
             Context::$IS_PRIVATE_APP ? Context::$API_SECRET_KEY : $this->accessToken;
 
         return parent::request(

--- a/tests/Clients/HttpHeadersTest.php
+++ b/tests/Clients/HttpHeadersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Webhooks;
+
+use Shopify\Clients\HttpHeaders;
+use ShopifyTest\BaseTestCase;
+
+final class HttpHeadersTest extends BaseTestCase
+{
+    private $rawHeaders = [
+        'Content-Type' => 'application/json',
+        'X-Custom-Header' => 1234,
+    ];
+
+    public function testHeadersAreNormalized()
+    {
+        $headers = new HttpHeaders($this->rawHeaders);
+        $this->assertSame(
+            [
+                'content-type' => 'application/json',
+                'x-custom-header' => '1234',
+            ],
+            $headers->toArray(),
+        );
+    }
+
+    public function testHasIsCaseInsensitive()
+    {
+        $headers = new HttpHeaders($this->rawHeaders);
+
+        $this->assertTrue($headers->has('Content-Type'));
+        $this->assertTrue($headers->has('content-type'));
+
+        $this->assertTrue($headers->has('X-Custom-Header'));
+        $this->assertTrue($headers->has('x-custom-header'));
+
+        $this->assertFalse($headers->has('not-there'));
+    }
+
+    public function testGetIsCaseInsensitiveAndReturnsStrings()
+    {
+        $headers = new HttpHeaders($this->rawHeaders);
+
+        $this->assertEquals('application/json', $headers->get('Content-Type'));
+        $this->assertEquals('application/json', $headers->get('content-type'));
+
+        $this->assertEquals('1234', $headers->get('X-Custom-Header'));
+        $this->assertEquals('1234', $headers->get('x-custom-header'));
+
+        $this->assertNull($headers->get('not-there'));
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds a new `HttpHeaders` object to help us handle headers consistently throughout the library. It can take in an array of headers and normalize them so don't have to worry about case-sensitivity, converting values to strings, etc.

### WHAT is this pull request doing?

Adding that new object.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
