### PR TITLE
Fix: Create new Transport for each Client request

### DIFF
--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -157,8 +157,10 @@ class Http
 
         $url = "https://$this->domain/$path{$formattedQuery}";
 
-        Context::$TRANSPORT->initializeRequest($url);
-        Context::$TRANSPORT->setMethod($method);
+        $transport = Context::$TRANSPORT_FACTORY->transport();
+
+        $transport->initializeRequest($url);
+        $transport->setMethod($method);
 
         $version = require dirname(__FILE__) . '/../version.php';
         $userAgentParts = ["Shopify Admin API Library for PHP v$version"];
@@ -172,7 +174,7 @@ class Http
             unset($headers['User-Agent']);
         }
 
-        Context::$TRANSPORT->setUserAgent(implode(' | ', $userAgentParts));
+        $transport->setUserAgent(implode(' | ', $userAgentParts));
 
         if ($body) {
             if (is_string($body)) {
@@ -184,7 +186,7 @@ class Http
                 };
             }
 
-            Context::$TRANSPORT->setBody($bodyString);
+            $transport->setBody($bodyString);
 
             $headers = array_merge(
                 [
@@ -199,13 +201,13 @@ class Http
         foreach ($headers as $header => $headerValue) {
             $headerOpts[] = "$header: $headerValue";
         }
-        Context::$TRANSPORT->setHeader($headerOpts);
+        $transport->setHeader($headerOpts);
 
         $currentTries = 0;
         do {
             $currentTries++;
 
-            $curlResponse = Context::$TRANSPORT->sendRequest();
+            $curlResponse = $transport->sendRequest();
 
             $response = new HttpResponse(
                 $curlResponse['statusCode'],

--- a/src/Clients/TransportFactory.php
+++ b/src/Clients/TransportFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shopify\Clients;
+
+class TransportFactory
+{
+    /**
+     * @return \Shopify\Clients\Transport Http transport
+     */
+    public function transport(): Transport
+    {
+        return new Curl();
+    }
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -6,8 +6,8 @@ namespace Shopify;
 
 use Shopify\Auth\SessionStorage;
 use Shopify\Clients\Curl;
-use Shopify\Clients\Transport;
 use Shopify\Auth\Scopes;
+use Shopify\Clients\TransportFactory;
 use Shopify\Exception\MissingArgumentException;
 use Shopify\Exception\PrivateAppException;
 use Shopify\Exception\UninitializedContextException;
@@ -19,7 +19,7 @@ class Context
     public static Scopes $SCOPES;
     public static ?string $HOST_NAME = null;
     public static ?SessionStorage $SESSION_STORAGE = null;
-    public static ?Transport $TRANSPORT = null;
+    public static TransportFactory $TRANSPORT_FACTORY;
     public static ?string $API_VERSION = null;
     public static bool $IS_EMBEDDED_APP = true;
     public static bool $IS_PRIVATE_APP = false;
@@ -79,7 +79,7 @@ class Context
         self::$SCOPES = $authScopes;
         self::$HOST_NAME = $hostName;
         self::$SESSION_STORAGE = $sessionStorage;
-        self::$TRANSPORT = new Curl();
+        self::$TRANSPORT_FACTORY = new TransportFactory();
         self::$API_VERSION = $apiVersion;
         self::$IS_EMBEDDED_APP = $isEmbeddedApp;
         self::$IS_PRIVATE_APP = $isPrivateApp;

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -7,6 +7,7 @@ namespace ShopifyTest;
 use PHPUnit\Framework\TestCase;
 use Shopify\Clients\Http;
 use Shopify\Clients\Transport;
+use Shopify\Clients\TransportFactory;
 use Shopify\Context;
 use Shopify\Exception\HttpRequestException;
 use ShopifyTest\Auth\MockSessionStorage;
@@ -35,7 +36,7 @@ class BaseTestCase extends TestCase
             isPrivateApp: false,
             userAgentPrefix: '',
         );
-        Context::$TRANSPORT = $this->createMock(Transport::class);
+        Context::$TRANSPORT_FACTORY = $this->createMock(TransportFactory::class);
         Context::$RETRY_TIME_IN_SECONDS = 0;
         $this->version = require dirname(__FILE__) . '/../src/version.php';
     }
@@ -149,6 +150,12 @@ class BaseTestCase extends TestCase
                 }
             });
 
-        Context::$TRANSPORT = $mock;
+        $factory = $this->createMock(TransportFactory::class);
+
+        $factory->expects($this->any())
+            ->method('transport')
+            ->willReturn($mock);
+
+        Context::$TRANSPORT_FACTORY = $factory;
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fix: Transport layer was shared across all request. This could cause a concurrency problems if multiple requests are fired in the same time.

### WHAT is this pull request doing?

Context now has a _transport factory_ instead of _transport_. Each call will create a new instance of Transport.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
