### PR TITLE
Add webhook processing method

### DIFF
--- a/src/Exception/InvalidWebhookException.php
+++ b/src/Exception/InvalidWebhookException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+use Shopify\Exception\ShopifyException;
+
+class InvalidWebhookException extends ShopifyException
+{
+}

--- a/src/Exception/MissingWebhookHandlerException.php
+++ b/src/Exception/MissingWebhookHandlerException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+use Shopify\Exception\ShopifyException;
+
+class MissingWebhookHandlerException extends ShopifyException
+{
+}

--- a/src/Webhooks/Handler.php
+++ b/src/Webhooks/Handler.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Webhooks;
+
+interface Handler
+{
+    /**
+     * Handles a webhook event from Shopify. If this method finishes executing, the webhook is considered successful.
+     *
+     * @param string $topic The webhook topic that was triggered
+     * @param string $shop  The shop that triggered the event
+     * @param array  $body  The payload of the webhook request from Shopify
+     */
+    public function handle(string $topic, string $shop, array $body): void;
+}

--- a/src/Webhooks/ProcessResponse.php
+++ b/src/Webhooks/ProcessResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Webhooks;
+
+final class ProcessResponse
+{
+    public function __construct(private bool $success, private ?string $errorMessage = null)
+    {
+    }
+
+    /**
+     * Whether the webhook was processed.
+     *
+     * @return bool
+     */
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * Returns the error message, if the webhook wasn't processed.
+     *
+     * @return string|null
+     */
+    public function getErrorMessage(): string | null
+    {
+        return $this->errorMessage;
+    }
+}

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -19,8 +19,6 @@ define('RUNNING_SHOPIFY_TESTS', 1);
 class BaseTestCase extends TestCase
 {
     protected string $domain = 'test-shop.myshopify.io';
-    protected array $requestDetails;
-    protected int $lastCheckedRequest;
     protected string $version;
 
     public function setUp(): void

--- a/tests/Webhooks/ProcessResponseTest.php
+++ b/tests/Webhooks/ProcessResponseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Webhooks;
+
+use Shopify\Webhooks\ProcessResponse;
+use ShopifyTest\BaseTestCase;
+
+final class ProcessResponseTest extends BaseTestCase
+{
+    public function testGetters()
+    {
+        $response = new ProcessResponse(true);
+        $this->assertTrue($response->isSuccess());
+        $this->assertNull($response->getErrorMessage());
+
+        $response = new ProcessResponse(false, 'Something went wrong');
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Something went wrong', $response->getErrorMessage());
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

This PR completes the webhooks functionality, by adding a method to process them, i.e. parse the headers and make sure the request is valid, and call the configured handler.

### WHAT is this pull request doing?

Adding a new `Shopify\Webhooks\Registry::process` method.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
