### PR TITLE
Linting improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "^3.5",
+        "squizlabs/php_codesniffer": "^3.6",
         "mikey179/vfsstream": "^1.6"
     },
     "scripts": {
         "test": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --color",
-        "lint": "./vendor/bin/phpcs --standard=PSR12 src"
+        "lint": "./vendor/bin/phpcs --standard=PSR12 src tests"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0a98856c905ee8bfbeac11b6c045116",
+    "content-hash": "b21dd108b3db005e44d0b040061da738",
     "packages": [
         {
             "name": "brick/math",

--- a/src/Auth/AccessTokenOnlineResponse.php
+++ b/src/Auth/AccessTokenOnlineResponse.php
@@ -7,14 +7,11 @@ namespace Shopify\Auth;
 final class AccessTokenOnlineResponse extends AccessTokenResponse
 {
     public function __construct(
-        // This is currently a bug until a new version of phpcs is released
-        // phpcs:disable
         protected string $accessToken,
         protected string $scope,
         private int $expiresIn,
         private string $associatedUserScope,
         private ?AccessTokenOnlineUserInfo $associatedUser = null,
-        // phpcs:enable
     ) {
     }
 

--- a/src/Auth/AccessTokenOnlineUserInfo.php
+++ b/src/Auth/AccessTokenOnlineUserInfo.php
@@ -7,8 +7,6 @@ namespace Shopify\Auth;
 final class AccessTokenOnlineUserInfo
 {
     public function __construct(
-        // This is currently a bug until a new version of phpcs is released
-        // phpcs:disable
         private int $id,
         private string $firstName,
         private string $lastName,
@@ -17,7 +15,6 @@ final class AccessTokenOnlineUserInfo
         private bool $accountOwner,
         private string $locale,
         private bool $collaborator,
-        // phpcs:enable
     ) {
     }
 

--- a/src/Auth/AccessTokenResponse.php
+++ b/src/Auth/AccessTokenResponse.php
@@ -7,11 +7,8 @@ namespace Shopify\Auth;
 class AccessTokenResponse
 {
     public function __construct(
-        // This is currently a bug until a new version of phpcs is released
-        // phpcs:disable
         protected string $accessToken,
         protected string $scope,
-        // phpcs:enable
     ) {
     }
 

--- a/src/Auth/OAuthCookie.php
+++ b/src/Auth/OAuthCookie.php
@@ -10,13 +10,11 @@ namespace Shopify\Auth;
 class OAuthCookie
 {
     public function __construct(
-        // phpcs:disable
         private string $value,
         private string $name,
         private int $expire = 0,
         private bool $secure = true,
-        private bool $httpOnly = true
-        // phpcs:enable
+        private bool $httpOnly = true,
     ) {
     }
 

--- a/src/Auth/Session.php
+++ b/src/Auth/Session.php
@@ -19,13 +19,10 @@ class Session
     private ?AccessTokenOnlineUserInfo $onlineAccessInfo = null;
 
     public function __construct(
-        // This is currently a bug until a new version of phpcs is released
-        // phpcs:disable
         private string $id,
         private string $shop,
         private bool $isOnline,
         private string $state,
-        // phpcs:enable
     ) {
         $this->shop = Utils::sanitizeShopDomain($shop);
     }

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -64,13 +64,11 @@ final class Registry
      * @throws \Shopify\Exception\WebhookRegistrationException
      */
     public static function register(
-        // phpcs:disable
         string $path,
         string $topic,
         string $shop,
         string $accessToken,
         string $deliveryMethod = self::DELIVERY_METHOD_HTTP,
-        // phpcs:enable
     ): RegisterResponse {
         if (!in_array($deliveryMethod, self::$DELIVERY_METHODS)) {
             throw new InvalidArgumentException("Unrecognized delivery method '$deliveryMethod'");

--- a/tests/Clients/MockRequest.php
+++ b/tests/Clients/MockRequest.php
@@ -7,7 +7,6 @@ namespace ShopifyTest\Clients;
 final class MockRequest
 {
     public function __construct(
-        // phpcs:disable
         public array $response,
         public ?string $url = null,
         public ?string $method = null,
@@ -17,7 +16,6 @@ final class MockRequest
         public ?string $error = null,
         public bool $allowOtherHeaders = true,
         public bool $isRetry = false,
-        // phpcs:enable
     ) {
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -37,14 +37,24 @@ final class UtilsTest extends BaseTestCase
     {
         $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('my-shop', 'myshopify.io'));
         $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('http://my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
-        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain('https://my-shop.myshopify.io', 'myshopify.io'));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(
+            'http://my-shop.myshopify.io',
+            'myshopify.io'
+        ));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(
+            'https://my-shop.myshopify.io',
+            'myshopify.io'
+        ));
+        $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(
+            'https://my-shop.myshopify.io',
+            'myshopify.io'
+        ));
         $this->assertEquals('my-shop.myshopify.io', Utils::sanitizeShopDomain(' MY-SHOP ', 'myshopify.io'));
     }
 
     public function testValidHmac()
     {
+        // phpcs:ignore
         $url = 'https://123456.ngrok.io/auth/shopify/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=654619d4b5a4f54795c3f40db18e4ed8b825f0abce16d1d75ab57e10c5e09490&shop=some-shop.myshopify.com&state=0.6784241404160823&timestamp=1337178173';
         $params = Utils::getQueryParams($url);
         $this->assertEquals(false, Utils::validateHmac(
@@ -55,6 +65,7 @@ final class UtilsTest extends BaseTestCase
 
     public function testInvalidHmac()
     {
+        // phpcs:ignore
         $url = 'https://123456.ngrok.io/auth/shopify/callback?code=0907a61c0c8d55e99db179b68161bc00&hmac=asdf&shop=some-shop.myshopify.com&state=0.6784241404160823&timestamp=1337178173';
         $params = Utils::getQueryParams($url);
         $this->assertEquals(false, Utils::validateHmac(


### PR DESCRIPTION
### WHY are these changes introduced?

PHPCS released a new version, which fixes the linting on constructor attribute promotion, so we should remove our ignore statements.

### WHAT is this pull request doing?

Upgrading the PHPCS version and removing the comments. Also, I realized we weren't linting the tests, so I fixed the linter command to include the `tests` folder as well.