### PR TITLE
Update header parsing

### DIFF
--- a/src/Clients/Curl.php
+++ b/src/Clients/Curl.php
@@ -30,19 +30,11 @@ class Curl implements Transport
      */
     private function executeRequest(): ?array
     {
-        $responseHeaders = [];
+        $headers = new HttpHeaders();
         $this->setCurlOption(
             CURLOPT_HEADERFUNCTION,
-            function ($curl, $header) use (&$responseHeaders) {
-                $len = strlen($header);
-                $header = explode(':', $header, 2);
-                if (count($header) < 2) {
-                    return $len;
-                }
-
-                $responseHeaders[strtolower(trim($header[0]))][] = trim($header[1]);
-
-                return $len;
+            function ($curl, $header) use (&$headers) {
+                return $headers->addRawHeader($header);
             }
         );
 
@@ -54,7 +46,7 @@ class Curl implements Transport
         $statusCode = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
         return [
             'statusCode' => $statusCode,
-            'headers' => $responseHeaders,
+            'headers' => $headers->toArray(),
             'body' => $responseBody,
         ];
     }

--- a/tests/Clients/HttpHeadersTest.php
+++ b/tests/Clients/HttpHeadersTest.php
@@ -51,4 +51,55 @@ final class HttpHeadersTest extends BaseTestCase
 
         $this->assertNull($headers->get('not-there'));
     }
+
+    public function testAddRawHeaderWillParseEachHeaderIntoItsKeyAndValue()
+    {
+        $builder = new HttpHeaders();
+        $builder->addRawHeader('x-request-id: 5023c4c7-2639-4a5a-aa28-1bdcbc0c5925');
+        $builder->addRawHeader('x-permitted-cross-domain-policies: none');
+        $this->assertEquals(
+            [
+                'x-request-id' => '5023c4c7-2639-4a5a-aa28-1bdcbc0c5925',
+                'x-permitted-cross-domain-policies' => 'none'
+            ],
+            $builder->toArray()
+        );
+    }
+
+    public function testAddRawHeaderTurnsHeadersShowingMultipleTimesToAnArray()
+    {
+        $builder = new HttpHeaders();
+        $builder->addRawHeader('set-cookie: _y=bdc37ee4-ab06-49...');
+        $builder->addRawHeader('set-cookie: _s=18d48dd0-a164-4b...');
+        $builder->addRawHeader('set-cookie: _shopify_y=bdc37ee4...');
+        $this->assertEquals(
+            [
+                'set-cookie' => ['_y=bdc37ee4-ab06-49...', '_s=18d48dd0-a164-4b...', '_shopify_y=bdc37ee4...']
+            ],
+            $builder->toArray()
+        );
+    }
+
+    public function testAddRawHeaderReturnsHeaderLength()
+    {
+        $builder = new HttpHeaders();
+        $this->assertEquals(34, $builder->addRawHeader('set-cookie: _y=bdc37ee4-ab06-49...'));
+    }
+
+    /**
+     * Bad formatted header, is a header that doesn't have `:`
+     */
+    public function testAddRawHeaderIgnoresBadFormattedHeadersAndReturnItsLength()
+    {
+        $builder = new HttpHeaders();
+        $this->assertEquals(10, $builder->addRawHeader('set-cookie'));
+        $this->assertEmpty($builder->toArray());
+    }
+
+    public function tesAddRawHeadertOnlyConsiderFirstColonWhenSplittingRawHeader()
+    {
+        $builder = new HttpHeaders();
+        $builder->addRawHeader('set-cookie: something:other thing');
+        $this->assertEquals(['set-cookie' => 'something:other thing'], $builder->toArray());
+    }
 }


### PR DESCRIPTION
This is the first of two PRs. the second is https://github.com/Shopify/shopify-php-api/pull/53 across the library.

### WHY are these changes introduced?

Update the format in which headers are parsed.

### WHAT is this pull request doing?

Update Curl response headers from this format:
```
Array(
[report-to] => Array
    (
        [0] => {"group":"network-errors",...
        [1] => {"group":"network-errors",...
    ),
```
to:
```
Array
(
    [date] => Wed, 21 Apr 2021 04:30:45 GMT
    [content-type] => application/json; charset=utf-8
    [report-to] => Array
    (
        [0] => {"group":"network-errors",...
        [1] => {"group":"network-errors",...
```

So, now we can access header values by calling `$response->getHeaders()['date']` instead of `$response->getHeaders()['date'][0]`

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
