### PR TITLE
Add a requestId field to HttpResponse

### DIFF
--- a/src/Clients/HttpHeaders.php
+++ b/src/Clients/HttpHeaders.php
@@ -10,6 +10,7 @@ namespace Shopify\Clients;
 final class HttpHeaders
 {
     public const X_SHOPIFY_ACCESS_TOKEN = "X-Shopify-Access-Token";
+    public const X_REQUEST_ID = "x-request-id";
 
     private array $headerSet = [];
 

--- a/src/Clients/HttpResponse.php
+++ b/src/Clients/HttpResponse.php
@@ -7,6 +7,8 @@ namespace Shopify\Clients;
 class HttpResponse
 {
 
+    private ?string $requestId;
+
     /**
      * HttpResponse constructor.
      *
@@ -19,6 +21,7 @@ class HttpResponse
         private array $headers = [],
         private array|string|null $body = null
     ) {
+        $this->requestId = $this->headers[HttpHeaders::X_REQUEST_ID] ?? null;
     }
 
     /**
@@ -43,5 +46,13 @@ class HttpResponse
     public function getBody(): array|string|null
     {
         return $this->body;
+    }
+
+    /**
+     * @return string|null request Id
+     */
+    public function getRequestId(): ?string
+    {
+        return $this->requestId;
     }
 }

--- a/tests/Clients/HttpResponseTest.php
+++ b/tests/Clients/HttpResponseTest.php
@@ -13,11 +13,25 @@ final class HttpResponseTest extends BaseTestCase
     {
         $response = new HttpResponse(
             statusCode: 1234,
-            headers: ['Header-1: ABCD', 'Header-2: DCBA'],
+            headers: ['Header-1' => 'ABCD', 'Header-2' => 'DCBA', 'x-request-id' => 'test-request-id'],
             body: 'This is a response!',
         );
         $this->assertEquals(1234, $response->getStatusCode());
-        $this->assertEquals(['Header-1: ABCD', 'Header-2: DCBA'], $response->getHeaders());
+        $this->assertEquals(
+            [
+                'Header-1' => 'ABCD',
+                'Header-2' => 'DCBA',
+                'x-request-id' => 'test-request-id'
+            ],
+            $response->getHeaders()
+        );
         $this->assertEquals('This is a response!', $response->getBody());
+        $this->assertEquals('test-request-id', $response->getRequestId());
+    }
+
+    public function testGetRequestIdReturnsNullIfHeaderIsMissing()
+    {
+        $response = new HttpResponse(statusCode: 1234);
+        $this->assertNull($response->getRequestId());
     }
 }


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

Add a `requestId` field to `HttpResponse` which is loaded from the `X-Request-Id` response header to make it easier to track requests.

### WHAT is this pull request doing?

Add a `requestId` field to `HttpResponse` which is loaded from the `X-Request-Id` response header 
## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
