### PR TITLE
Add optional logger attribute to Context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require": {
         "php": ">=8.0",
-        "ramsey/uuid": "^4.1"
+        "ramsey/uuid": "^4.1",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39961abdccc01ed7c6e68351c5b3ec8c",
+    "content-hash": "da9422088a62635770bf4959c71b445d",
     "packages": [
         {
             "name": "brick/math",
@@ -61,6 +61,56 @@
                 }
             ],
             "time": "2021-01-20T22:51:39+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "ramsey/collection",

--- a/src/Context.php
+++ b/src/Context.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopify;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Shopify\Auth\SessionStorage;
 use Shopify\Clients\Curl;
 use Shopify\Auth\Scopes;
@@ -25,20 +27,23 @@ class Context
     public static bool $IS_PRIVATE_APP = false;
     public static ?string $USER_AGENT_PREFIX = null;
     public static int $RETRY_TIME_IN_SECONDS = 1;
+    public static ?LoggerInterface $LOGGER = null;
     private static bool $IS_INITIALIZED = false;
 
     /**
      * Initializes Context object
      *
-     * @param string         $apiKey          App API key
-     * @param string         $apiSecretKey    App API secret
-     * @param string|array   $scopes          App scopes
-     * @param string         $hostName        App host name e.g. www.google.ca
-     * @param SessionStorage $sessionStorage  Session storage strategy
-     * @param string         $apiVersion      App API key, defaults to unstable
-     * @param bool           $isEmbeddedApp   Whether the app is an embedded app, defaults to true
-     * @param bool           $isPrivateApp    Whether the app is a private app, defaults to false
-     * @param string         $userAgentPrefix Prefix for user agent header sent with a request, defaults to empty string
+     * @param string          $apiKey          App API key
+     * @param string          $apiSecretKey    App API secret
+     * @param string|array    $scopes          App scopes
+     * @param string          $hostName        App host name e.g. www.google.ca
+     * @param SessionStorage  $sessionStorage  Session storage strategy
+     * @param string          $apiVersion      App API key, defaults to unstable
+     * @param bool            $isEmbeddedApp   Whether the app is an embedded app, defaults to true
+     * @param bool            $isPrivateApp    Whether the app is a private app, defaults to false
+     * @param string          $userAgentPrefix Prefix for user agent header sent with a request, defaults to empty
+     *                                         string
+     * @param LoggerInterface $logger          App logger, so the library can add its own logs to it
      */
     public static function initialize(
         string $apiKey,
@@ -50,6 +55,7 @@ class Context
         bool $isEmbeddedApp = true,
         bool $isPrivateApp = false,
         string $userAgentPrefix = '',
+        LoggerInterface $logger = null,
     ): void {
         $authScopes = new Scopes($scopes);
 
@@ -84,6 +90,7 @@ class Context
         self::$IS_EMBEDDED_APP = $isEmbeddedApp;
         self::$IS_PRIVATE_APP = $isPrivateApp;
         self::$USER_AGENT_PREFIX = $userAgentPrefix;
+        self::$LOGGER = $logger;
 
         self::$IS_INITIALIZED = true;
     }
@@ -111,5 +118,24 @@ class Context
         if (self::$IS_PRIVATE_APP) {
             throw new PrivateAppException($message);
         }
+    }
+
+    /**
+     * Logs a message using the defined callback. If none is set, the message is ignored.
+     *
+     * @param string $message The message to log
+     * @param string $level   One of the \Psr\Log\LogLevel::* consts, defaults to INFO
+     *
+     * @throws \Shopify\Exception\UninitializedContextException
+     */
+    public static function log(string $message, string $level = LogLevel::INFO): void
+    {
+        self::throwIfUninitialized();
+
+        if (!self::$LOGGER) {
+            return;
+        }
+
+        self::$LOGGER->log($level, $message);
     }
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -35,6 +35,7 @@ class BaseTestCase extends TestCase
             isEmbeddedApp: true,
             isPrivateApp: false,
             userAgentPrefix: '',
+            logger: null,
         );
         Context::$TRANSPORT_FACTORY = $this->createMock(TransportFactory::class);
         Context::$RETRY_TIME_IN_SECONDS = 0;

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ShopifyTest;
 
+use Psr\Log\LogLevel;
+use Psr\Log\Test\TestLogger;
 use Shopify\Auth\Scopes;
 use Shopify\Context;
 use ShopifyTest\Auth\MockSessionStorage;
@@ -92,5 +94,42 @@ final class ContextTest extends BaseTestCase
         $this->expectException('\Shopify\Exception\PrivateAppException');
         $this->expectExceptionMessage('BOOOOOO');
         Context::throwIfPrivateApp('BOOOOOO');
+    }
+
+    public function testCanAddOverrideLogger()
+    {
+        $testLogger = new TestLogger();
+
+        Context::log('Logging something!', LogLevel::DEBUG);
+        $this->assertEmpty($testLogger->records);
+
+        Context::$LOGGER = $testLogger;
+
+        Context::log('Defaults to info');
+        $this->assertTrue($testLogger->hasInfoThatContains('Defaults to info'));
+
+        Context::log('Debug log', LogLevel::DEBUG);
+        $this->assertTrue($testLogger->hasDebugThatContains('Debug log'));
+
+        Context::log('Info log', LogLevel::INFO);
+        $this->assertTrue($testLogger->hasInfoThatContains('Info log'));
+
+        Context::log('Notice log', LogLevel::NOTICE);
+        $this->assertTrue($testLogger->hasNoticeThatContains('Notice log'));
+
+        Context::log('Warning log', LogLevel::WARNING);
+        $this->assertTrue($testLogger->hasWarningThatContains('Warning log'));
+
+        Context::log('Err log', LogLevel::ERROR);
+        $this->assertTrue($testLogger->hasErrorThatContains('Err log'));
+
+        Context::log('Crit log', LogLevel::CRITICAL);
+        $this->assertTrue($testLogger->hasCriticalThatContains('Crit log'));
+
+        Context::log('Alert log', LogLevel::ALERT);
+        $this->assertTrue($testLogger->hasAlertThatContains('Alert log'));
+
+        Context::log('Emerg log', LogLevel::EMERGENCY);
+        $this->assertTrue($testLogger->hasEmergencyThatContains('Emerg log'));
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes we want to log things in the library to raise information to the app calling it. Since each framework may use its own logging method, we should allow apps to set a callback for logging that calls through to their app's logging methods.

### WHAT is this pull request doing?

Adds a new `Context::$LOG_CALLBACK` attribute which is just a function that gets called when `Context::log` is called. If no function is set, logging is ignored so `log` is safe to call at any point.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
