### PR TITLE
Replace headers array with http headers class

### DIFF
--- a/src/Clients/Curl.php
+++ b/src/Clients/Curl.php
@@ -46,7 +46,7 @@ class Curl implements Transport
         $statusCode = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
         return [
             'statusCode' => $statusCode,
-            'headers' => $headers->toArray(),
+            'headers' => $headers,
             'body' => $responseBody,
         ];
     }

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -216,7 +216,7 @@ class Http
             );
 
             if (in_array($curlResponse['statusCode'], self::RETRIABLE_STATUS_CODES)) {
-                $retryAfter = $curlResponse['headers']['Retry-After'] ?? Context::$RETRY_TIME_IN_SECONDS;
+                $retryAfter = $curlResponse['headers']->get('Retry-After') ?? Context::$RETRY_TIME_IN_SECONDS;
                 usleep($retryAfter * 1000000);
             } else {
                 break;

--- a/src/Clients/HttpResponse.php
+++ b/src/Clients/HttpResponse.php
@@ -12,16 +12,16 @@ class HttpResponse
     /**
      * HttpResponse constructor.
      *
-     * @param int               $statusCode
-     * @param array             $headers
-     * @param array|string|null $body
+     * @param int                          $statusCode
+     * @param \Shopify\Clients\HttpHeaders $headers
+     * @param array|string|null            $body
      */
     public function __construct(
         private int $statusCode,
-        private array $headers = [],
+        private HttpHeaders $headers,
         private array|string|null $body = null
     ) {
-        $this->requestId = $this->headers[HttpHeaders::X_REQUEST_ID] ?? null;
+        $this->requestId = $this->headers->get(HttpHeaders::X_REQUEST_ID);
     }
 
     /**
@@ -33,9 +33,9 @@ class HttpResponse
     }
 
     /**
-     * @return array HTTP headers
+     * @return \Shopify\Clients\HttpHeaders HTTP headers
      */
-    public function getHeaders(): array
+    public function getHeaders(): HttpHeaders
     {
         return $this->headers;
     }

--- a/src/Clients/Rest.php
+++ b/src/Clients/Rest.php
@@ -75,8 +75,8 @@ class Rest extends Http
     {
         $pageInfo = null;
 
-        if (array_key_exists('link', $response->getHeaders())) {
-            $pageInfo = PageInfo::fromLinkHeader($response->getHeaders()['link']);
+        if ($response->getHeaders()->has('link')) {
+            $pageInfo = PageInfo::fromLinkHeader($response->getHeaders()->get('link'));
         }
         return $pageInfo;
     }

--- a/src/Clients/RestResponse.php
+++ b/src/Clients/RestResponse.php
@@ -9,13 +9,13 @@ class RestResponse extends HttpResponse
      * RestResponse constructor.
      *
      * @param int                            $statusCode
-     * @param array                          $headers
+     * @param \Shopify\Clients\HttpHeaders   $headers
      * @param array|string|null              $body
      * @param \Shopify\Clients\PageInfo|null $pageInfo
      */
     public function __construct(
         int $statusCode,
-        array $headers = [],
+        HttpHeaders $headers,
         array|string|null $body = null,
         private PageInfo|null $pageInfo = null
     ) {

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -6,6 +6,7 @@ namespace ShopifyTest;
 
 use PHPUnit\Framework\TestCase;
 use Shopify\Clients\Http;
+use Shopify\Clients\HttpHeaders;
 use Shopify\Clients\Transport;
 use Shopify\Clients\TransportFactory;
 use Shopify\Context;
@@ -73,7 +74,7 @@ class BaseTestCase extends TestCase
         return [
             'statusCode' => $statusCode,
             'body' => $body,
-            'headers' => $headers,
+            'headers' => new HttpHeaders($headers),
             'error' => $error,
         ];
     }

--- a/tests/Clients/HttpResponseTest.php
+++ b/tests/Clients/HttpResponseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShopifyTest\Clients;
 
+use Shopify\Clients\HttpHeaders;
 use Shopify\Clients\HttpResponse;
 use ShopifyTest\BaseTestCase;
 
@@ -13,17 +14,17 @@ final class HttpResponseTest extends BaseTestCase
     {
         $response = new HttpResponse(
             statusCode: 1234,
-            headers: ['Header-1' => 'ABCD', 'Header-2' => 'DCBA', 'x-request-id' => 'test-request-id'],
+            headers: new HttpHeaders(['Header-1' => 'ABCD', 'Header-2' => 'DCBA', 'x-request-id' => 'test-request-id']),
             body: 'This is a response!',
         );
         $this->assertEquals(1234, $response->getStatusCode());
         $this->assertEquals(
             [
-                'Header-1' => 'ABCD',
-                'Header-2' => 'DCBA',
-                'x-request-id' => 'test-request-id'
+                'x-request-id' => 'test-request-id',
+                'header-1' => 'ABCD',
+                'header-2' => 'DCBA',
             ],
-            $response->getHeaders()
+            $response->getHeaders()->toArray()
         );
         $this->assertEquals('This is a response!', $response->getBody());
         $this->assertEquals('test-request-id', $response->getRequestId());
@@ -31,7 +32,7 @@ final class HttpResponseTest extends BaseTestCase
 
     public function testGetRequestIdReturnsNullIfHeaderIsMissing()
     {
-        $response = new HttpResponse(statusCode: 1234);
+        $response = new HttpResponse(statusCode: 1234, headers: new HttpHeaders());
         $this->assertNull($response->getRequestId());
     }
 }

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShopifyTest\Clients;
 
 use Shopify\Clients\Http;
+use Shopify\Clients\HttpHeaders;
 use Shopify\Clients\HttpResponse;
 use Shopify\Context;
 use ShopifyTest\BaseTestCase;
@@ -37,7 +38,7 @@ final class HttpTest extends BaseTestCase
         ]);
 
         $client = new Http($this->domain);
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
         $response = $client->get(path: 'test/path', headers: $headers);
         $this->assertEquals($expectedResponse, $response);
     }
@@ -57,7 +58,7 @@ final class HttpTest extends BaseTestCase
         ]);
 
         $client = new Http($this->domain);
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
         $response = $client->get(path: 'test/path', headers: $headers, query: ["path" => "some_path"]);
         $this->assertEquals($expectedResponse, $response);
     }
@@ -87,7 +88,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->post(
             path: 'test/path',
@@ -124,7 +125,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->put(
             path: 'test/path',
@@ -152,7 +153,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->delete(path: 'test/path', headers: $headers, query: ["path" => "some_path"]);
         $this->assertEquals($expectedResponse, $response);
@@ -180,7 +181,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
 
         $response = $client->post(path: 'test/path', body: $body);
@@ -214,7 +215,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
 
         $response = $client->post(path: 'test/path', body: $this->product1, dataType: Http::DATA_TYPE_URL_ENCODED);
@@ -320,7 +321,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
+        $expectedResponse = new HttpResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->get(path: 'test/path', tries: 3);
         $this->assertEquals($expectedResponse, $response);
@@ -347,7 +348,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(500, ['X-Is-Last-Test-Request' => true]);
+        $expectedResponse = new HttpResponse(500, new HttpHeaders(['X-Is-Last-Test-Request' => true]));
 
         $response = $client->get(path: 'test/path', tries: 3);
         $this->assertEquals($expectedResponse, $response);
@@ -370,7 +371,7 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(400, ['X-Is-Last-Test-Request' => true]);
+        $expectedResponse = new HttpResponse(400, new HttpHeaders(['X-Is-Last-Test-Request' => true]));
 
         $response = $client->get(path: 'test/path', tries: 10);
         $this->assertEquals($expectedResponse, $response);

--- a/tests/Clients/RestTest.php
+++ b/tests/Clients/RestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShopifyTest\Clients;
 
 use Shopify\Clients\Http;
+use Shopify\Clients\HttpHeaders;
 use Shopify\Clients\Rest;
 use Shopify\Clients\RestResponse;
 use Shopify\Context;
@@ -55,7 +56,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->get(path: 'products', headers: $headers);
 
@@ -79,7 +80,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->get(path: 'products', headers: $headers);
 
@@ -101,7 +102,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->get(path: 'products', query: ["path" => "some_path"]);
 
@@ -136,7 +137,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->post(path: 'products', body: $postData, dataType: Http::DATA_TYPE_JSON);
 
@@ -171,7 +172,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->post(
             path: 'products',
@@ -215,7 +216,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->post(path: 'products', body: $postData, dataType: Http::DATA_TYPE_URL_ENCODED);
 
@@ -250,7 +251,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->put(
             path: 'products/123',
@@ -279,7 +280,7 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
+        $expectedResponse = new RestResponse(200, new HttpHeaders(), $this->successResponse);
 
         $response = $client->delete('products', $headers, query: ["path" => "some_path"]);
 


### PR DESCRIPTION
This is the second of two PRs. The first is https://github.com/Shopify/shopify-php-api/pull/46

### WHY are these changes introduced?

HttpHeaders is a better abstraction compared to plain arrays

### WHAT is this pull request doing?

This PR is mostly mechanical replacement of the usage and updating tests

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
