### PR TITLE
Add API deprecation logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .phpunit.cache
 /vendor/
 .idea
+src/.last_api_deprecation_warning

--- a/src/Clients/HttpHeaders.php
+++ b/src/Clients/HttpHeaders.php
@@ -53,7 +53,7 @@ final class HttpHeaders
         }
 
         list($header) = $this->normalizeHeader($header);
-        return $this->headerSet[$header];
+        return implode(',', $this->headerSet[$header]);
     }
 
     /**
@@ -90,6 +90,8 @@ final class HttpHeaders
      */
     private function normalizeHeader(string $header, mixed $value = null): array
     {
-        return [strtolower($header), $value ? (string)$value : null];
+        $value = array_map(fn($item) => (string)$item, (array)$value);
+
+        return [strtolower($header), $value];
     }
 }

--- a/src/Clients/HttpResponse.php
+++ b/src/Clients/HttpResponse.php
@@ -6,7 +6,6 @@ namespace Shopify\Clients;
 
 class HttpResponse
 {
-
     private ?string $requestId;
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -62,7 +62,7 @@ class Context
         $requiredValues = [
             'apiKey' => $apiKey,
             'apiSecretKey' => $apiSecretKey,
-            'scopes' => implode($scopes),
+            'scopes' => implode((array)$scopes),
             'hostName' => $hostName,
         ];
         $missing = array();

--- a/tests/Clients/HttpHeadersTest.php
+++ b/tests/Clients/HttpHeadersTest.php
@@ -19,8 +19,8 @@ final class HttpHeadersTest extends BaseTestCase
         $headers = new HttpHeaders($this->rawHeaders);
         $this->assertSame(
             [
-                'content-type' => 'application/json',
-                'x-custom-header' => '1234',
+                'content-type' => ['application/json'],
+                'x-custom-header' => ['1234'],
             ],
             $headers->toArray(),
         );

--- a/tests/Clients/HttpResponseTest.php
+++ b/tests/Clients/HttpResponseTest.php
@@ -17,13 +17,13 @@ final class HttpResponseTest extends BaseTestCase
             body: 'This is a response!',
         );
         $this->assertEquals(1234, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [
                 'Header-1' => ['ABCD'],
                 'Header-2' => ['DCBA'],
-                'x-request-id' => ['test-request-id']
+                'x-request-id' => ['test-request-id'],
             ],
-            $response->getHeaders()
+            $response->getHeaders(),
         );
         $this->assertEquals('This is a response!', $response->getBody());
         $this->assertEquals('test-request-id', $response->getRequestId());

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -106,30 +106,30 @@ final class ContextTest extends BaseTestCase
         Context::$LOGGER = $testLogger;
 
         Context::log('Defaults to info');
-        $this->assertTrue($testLogger->hasInfoThatContains('Defaults to info'));
+        $this->assertTrue($testLogger->hasInfo('Defaults to info'));
 
         Context::log('Debug log', LogLevel::DEBUG);
-        $this->assertTrue($testLogger->hasDebugThatContains('Debug log'));
+        $this->assertTrue($testLogger->hasDebug('Debug log'));
 
         Context::log('Info log', LogLevel::INFO);
-        $this->assertTrue($testLogger->hasInfoThatContains('Info log'));
+        $this->assertTrue($testLogger->hasInfo('Info log'));
 
         Context::log('Notice log', LogLevel::NOTICE);
-        $this->assertTrue($testLogger->hasNoticeThatContains('Notice log'));
+        $this->assertTrue($testLogger->hasNotice('Notice log'));
 
         Context::log('Warning log', LogLevel::WARNING);
-        $this->assertTrue($testLogger->hasWarningThatContains('Warning log'));
+        $this->assertTrue($testLogger->hasWarning('Warning log'));
 
         Context::log('Err log', LogLevel::ERROR);
-        $this->assertTrue($testLogger->hasErrorThatContains('Err log'));
+        $this->assertTrue($testLogger->hasError('Err log'));
 
         Context::log('Crit log', LogLevel::CRITICAL);
-        $this->assertTrue($testLogger->hasCriticalThatContains('Crit log'));
+        $this->assertTrue($testLogger->hasCritical('Crit log'));
 
         Context::log('Alert log', LogLevel::ALERT);
-        $this->assertTrue($testLogger->hasAlertThatContains('Alert log'));
+        $this->assertTrue($testLogger->hasAlert('Alert log'));
 
         Context::log('Emerg log', LogLevel::EMERGENCY);
-        $this->assertTrue($testLogger->hasEmergencyThatContains('Emerg log'));
+        $this->assertTrue($testLogger->hasEmergency('Emerg log'));
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes the APIs might return a header indicating that the request hit a deprecated feature on Shopify. We want to make sure to surface those to partners in a non-invasive way.

### WHAT is this pull request doing?

Looking for the headers in HTTP responses, and using `Context::$LOGGER` to log a warning to the app if they're present, once every 5 minutes.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
