### PR TITLE
Retry on 429 after delay

### DIFF
--- a/.github/workflows/markdown_link_checker_config.json
+++ b/.github/workflows/markdown_link_checker_config.json
@@ -9,5 +9,7 @@
       "pattern": "^/",
       "replacement": "{{BASEURL}}/"
     }
-  ]
+  ],
+  "retryOn429": true,
+  "fallbackRetryDelay": "1s"
 }


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* Future-proofing

### What is this pull request doing? 📋 
* Have GitHub action retry links that return `429 Too Many Requests` after 1 second
