### PR TITLE
Use Standard HTTP response

### DIFF
--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -312,13 +312,13 @@ class OAuth
         $client = new Http($session->getShop());
         $response = self::requestAccessToken($client, $post);
         if ($response->getStatusCode() !== 200) {
-            throw new HttpRequestException("Failed to get access token: {$response->getBody()}");
+            throw new HttpRequestException("Failed to get access token: {$response->getDecodedBody()}");
         }
 
         if ($session->isOnline()) {
-            return self::buildAccessTokenOnlineResponse($response->getBody());
+            return self::buildAccessTokenOnlineResponse($response->getDecodedBody());
         } else {
-            return self::buildAccessTokenResponse($response->getBody());
+            return self::buildAccessTokenResponse($response->getDecodedBody());
         }
     }
 

--- a/src/Clients/Rest.php
+++ b/src/Clients/Rest.php
@@ -52,10 +52,12 @@ class Rest extends Http
         );
 
         return new RestResponse(
-            $response->getStatusCode(),
-            $response->getHeaders(),
-            $response->getBody(),
-            $this->getPageInfo($response)
+            status: $response->getStatusCode(),
+            headers: $response->getHeaders(),
+            body: $response->getBody(),
+            version: $response->getProtocolVersion(),
+            reason: $response->getReasonPhrase(),
+            pageInfo: $this->getPageInfo($response)
         );
     }
 

--- a/src/Clients/RestResponse.php
+++ b/src/Clients/RestResponse.php
@@ -6,20 +6,17 @@ class RestResponse extends HttpResponse
 {
 
     /**
-     * RestResponse constructor.
-     *
-     * @param int                            $statusCode
-     * @param array                          $headers
-     * @param array|string|null              $body
-     * @param \Shopify\Clients\PageInfo|null $pageInfo
+     * {@inheritDoc}
      */
     public function __construct(
-        int $statusCode,
+        $status = 200,
         array $headers = [],
-        array|string|null $body = null,
+        $body = null,
+        $version = '1.1',
+        $reason = null,
         private PageInfo|null $pageInfo = null
     ) {
-        parent::__construct($statusCode, $headers, $body);
+        parent::__construct($status, $headers, $body, $version, $reason);
     }
 
     /**

--- a/src/Webhooks/Registry.php
+++ b/src/Webhooks/Registry.php
@@ -198,7 +198,7 @@ final class Registry
         );
 
         $checkStatusCode = $checkResponse->getStatusCode();
-        $checkBody = $checkResponse->getBody();
+        $checkBody = $checkResponse->getDecodedBody();
 
         if ($checkStatusCode !== 200) {
             throw new WebhookRegistrationException(
@@ -263,7 +263,7 @@ final class Registry
         );
 
         $statusCode = $registerResponse->getStatusCode();
-        $body = $registerResponse->getBody();
+        $body = $registerResponse->getDecodedBody();
         if ($statusCode !== 200) {
             throw new WebhookRegistrationException(
                 <<<ERROR

--- a/tests/Clients/GraphqlTest.php
+++ b/tests/Clients/GraphqlTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace ShopifyTest\Clients;
 
 use Shopify\Clients\Graphql;
-use Shopify\Clients\HttpResponse;
 use Shopify\Context;
 use ShopifyTest\BaseTestCase;
+use Shopify\Exception\MissingArgumentException;
+use ShopifyTest\HttpResponseMatcher;
 
 final class GraphqlTest extends BaseTestCase
 {
@@ -69,15 +70,8 @@ final class GraphqlTest extends BaseTestCase
             )
         ]);
 
-        $expectedResponse = new HttpResponse(
-            statusCode: 200,
-            headers: [],
-            body: json_decode($this->successResponse, true)
-        );
-
         $response = $client->query(data: $this->testQueryString);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: json_decode($this->successResponse, true)));
     }
 
     public function testCanQueryWithDataArray()
@@ -99,15 +93,8 @@ final class GraphqlTest extends BaseTestCase
             )
         ]);
 
-        $expectedResponse = new HttpResponse(
-            statusCode: 200,
-            headers: [],
-            body: json_decode($this->successResponse, true)
-        );
-
         $response = $client->query(data: $this->testQueryArray);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: json_decode($this->successResponse, true)));
     }
 
     public function testCanQueryWithExtraHeaders()
@@ -131,14 +118,7 @@ final class GraphqlTest extends BaseTestCase
             )
         ]);
 
-        $expectedResponse = new HttpResponse(
-            statusCode: 200,
-            headers: [],
-            body: json_decode($this->successResponse, true)
-        );
-
         $response = $client->query(data: $this->testQueryString, extraHeaders: $extraHeaders);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: json_decode($this->successResponse, true)));
     }
 }

--- a/tests/Clients/HttpResponseTest.php
+++ b/tests/Clients/HttpResponseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShopifyTest\Clients;
 
+use JsonException;
 use Shopify\Clients\HttpResponse;
 use ShopifyTest\BaseTestCase;
 
@@ -12,11 +13,11 @@ final class HttpResponseTest extends BaseTestCase
     public function testGetters()
     {
         $response = new HttpResponse(
-            statusCode: 1234,
+            status: 200,
             headers: ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA'], 'x-request-id' => ['test-request-id']],
-            body: 'This is a response!',
+            body: '{"name": "Shoppity Shop"}',
         );
-        $this->assertEquals(1234, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEqualsCanonicalizing(
             [
                 'Header-1' => ['ABCD'],
@@ -25,13 +26,21 @@ final class HttpResponseTest extends BaseTestCase
             ],
             $response->getHeaders(),
         );
-        $this->assertEquals('This is a response!', $response->getBody());
+        $this->assertEquals(['name' => 'Shoppity Shop'], $response->getDecodedBody());
         $this->assertEquals('test-request-id', $response->getRequestId());
     }
 
     public function testGetRequestIdReturnsNullIfHeaderIsMissing()
     {
-        $response = new HttpResponse(statusCode: 1234);
+        $response = new HttpResponse(status: 200);
         $this->assertNull($response->getRequestId());
+    }
+
+    public function testGetDecodedBodyWillThrwoExceptionIfBodyIsNotJson()
+    {
+        $response = new HttpResponse(body: "not-json");
+
+        $this->expectException(JsonException::class);
+        $response->getDecodedBody();
     }
 }

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -8,9 +8,9 @@ use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\Test\TestLogger;
 use Shopify\Clients\Http;
-use Shopify\Clients\HttpResponse;
 use Shopify\Context;
 use ShopifyTest\BaseTestCase;
+use ShopifyTest\HttpResponseMatcher;
 
 final class HttpTest extends BaseTestCase
 {
@@ -40,9 +40,8 @@ final class HttpTest extends BaseTestCase
         ]);
 
         $client = new Http($this->domain);
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
         $response = $client->get(path: 'test/path', headers: $headers);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testGetRequest()
@@ -60,9 +59,8 @@ final class HttpTest extends BaseTestCase
         ]);
 
         $client = new Http($this->domain);
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
         $response = $client->get(path: 'test/path', headers: $headers, query: ["path" => "some_path"]);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testPostRequest()
@@ -90,7 +88,6 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
         $response = $client->post(
             path: 'test/path',
@@ -98,7 +95,7 @@ final class HttpTest extends BaseTestCase
             headers: $headers,
             query: ["path" => "some_path"]
         );
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
 
@@ -127,7 +124,6 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
 
         $response = $client->put(
             path: 'test/path',
@@ -135,7 +131,7 @@ final class HttpTest extends BaseTestCase
             headers: $headers,
             query: ["path" => "some_path"]
         );
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testDeleteRequest()
@@ -155,10 +151,8 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
-
         $response = $client->delete(path: 'test/path', headers: $headers, query: ["path" => "some_path"]);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testPostWithStringBody()
@@ -183,11 +177,8 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
-
-
         $response = $client->post(path: 'test/path', body: $body);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testUserAgent()
@@ -293,10 +284,8 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(200, [], $this->successResponse);
-
         $response = $client->get(path: 'test/path', tries: 3);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testRetryStopsAfterReachingTheLimit()
@@ -324,10 +313,8 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(500, ['X-Is-Last-Test-Request' => [true]]);
-
         $response = $client->get(path: 'test/path', tries: 3);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(500, ['X-Is-Last-Test-Request' => [true]]));
     }
 
     public function testRetryStopsOnNonRetriableError()
@@ -349,10 +336,8 @@ final class HttpTest extends BaseTestCase
 
         $client = new Http($this->domain);
 
-        $expectedResponse = new HttpResponse(400, ['X-Is-Last-Test-Request' => [true]]);
-
         $response = $client->get(path: 'test/path', tries: 10);
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(400, ['X-Is-Last-Test-Request' => [true]]));
     }
 
     public function testDeprecatedRequestsAreLogged()

--- a/tests/Clients/RestTest.php
+++ b/tests/Clients/RestTest.php
@@ -6,9 +6,9 @@ namespace ShopifyTest\Clients;
 
 use Shopify\Clients\Http;
 use Shopify\Clients\Rest;
-use Shopify\Clients\RestResponse;
 use Shopify\Context;
 use ShopifyTest\BaseTestCase;
+use ShopifyTest\HttpResponseMatcher;
 
 class RestTest extends BaseTestCase
 {
@@ -55,11 +55,8 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->get(path: 'products', headers: $headers);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakeGetRequest()
@@ -79,11 +76,8 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->get(path: 'products', headers: $headers);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakeGetRequestWithPathInQuery()
@@ -101,11 +95,8 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->get(path: 'products', query: ["path" => "some_path"]);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakePostRequestWithJsonData()
@@ -136,11 +127,8 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->post(path: 'products', body: $postData, dataType: Http::DATA_TYPE_JSON);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakePostRequestWithJsonDataAndPathInQuery()
@@ -171,16 +159,13 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->post(
             path: 'products',
             body: $postData,
             dataType: Http::DATA_TYPE_JSON,
             query: ["path" => "some_path"]
         );
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakePutRequestWithJsonData()
@@ -211,16 +196,13 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->put(
             path: 'products/123',
             body: $postData,
             dataType: Http::DATA_TYPE_JSON,
             query: ["path" => "some_path"]
         );
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanMakeDeleteRequest()
@@ -240,11 +222,8 @@ class RestTest extends BaseTestCase
             ),
         ]);
 
-        $expectedResponse = new RestResponse(200, [], $this->successResponse);
-
         $response = $client->delete('products', $headers, query: ["path" => "some_path"]);
-
-        $this->assertEquals($expectedResponse, $response);
+        $this->assertThat($response, new HttpResponseMatcher(decodedBody: $this->successResponse));
     }
 
     public function testCanRequestNextAndPreviousPagesUntilTheyRunOut()

--- a/tests/Clients/StorefrontTest.php
+++ b/tests/Clients/StorefrontTest.php
@@ -51,7 +51,7 @@ final class StorefrontTest extends BaseTestCase
 
         $response = $client->query(data: $this->query);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals($this->successResponse, $response->getBody());
+        $this->assertEquals($this->successResponse, $response->getDecodedBody());
         $this->assertEquals('request_id', $response->getRequestId());
     }
 
@@ -81,7 +81,7 @@ final class StorefrontTest extends BaseTestCase
 
         $response = $client->query(data: $this->query);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals($this->successResponse, $response->getBody());
+        $this->assertEquals($this->successResponse, $response->getDecodedBody());
         $this->assertEquals('request_id', $response->getRequestId());
     }
 
@@ -110,7 +110,7 @@ final class StorefrontTest extends BaseTestCase
 
         $response = $client->query(data: $this->query);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals($this->successResponse, $response->getBody());
+        $this->assertEquals($this->successResponse, $response->getDecodedBody());
         $this->assertEquals('request_id', $response->getRequestId());
     }
 }

--- a/tests/HttpResponseMatcher.php
+++ b/tests/HttpResponseMatcher.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Shopify\Clients\HttpResponse;
+
+class HttpResponseMatcher extends Constraint
+{
+
+    /**
+     * HttpResponseMatcher constructor.
+     *
+     * @param int        $statusCode  HTTP Status Code
+     * @param array      $headers     Headers formatted as `[headerName] => [value1, value2, ...]
+     * @param array|null $decodedBody Body as an array
+     */
+    public function __construct(
+        private int $statusCode = 200,
+        private array $headers = [],
+        private array|null $decodedBody = null
+    ) {
+    }
+
+    protected function matches($other): bool
+    {
+        if (!($other instanceof HttpResponse)) {
+            return false;
+        }
+
+        return $this->statusCode === $other->getStatusCode()
+            && $this->headers == $other->getHeaders()
+            && $this->decodedBody === $other->getDecodedBody();
+    }
+
+
+    public function toString(): string
+    {
+        return "HttpResponseMatcher";
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        $diff = [];
+        if ($this->statusCode !== $other->getStatusCode()) {
+            $diff[] = $this->diffLine("Status Code", $this->statusCode, $other->getStatusCode());
+        }
+        if ($this->headers != $other->getHeaders()) {
+            $diff[] = $this->diffLine("Headers", $this->headers, $other->getHeaders());
+        }
+        if ($this->decodedBody != $other->getDecodedBody()) {
+            $diff[] = $this->diffLine("Decoded Body", $this->decodedBody, $other->getDecodedBody());
+        }
+
+        return implode("\n", $diff);
+    }
+
+    private function diffLine(string $header, mixed $expected, mixed $actual): string
+    {
+        $expected = print_r($expected, true);
+        $actual = print_r($actual, true);
+
+        return "## $header:\n `$actual` Doesn't match expected `$expected`";
+    }
+}

--- a/tests/HttpResponseMatcherTest.php
+++ b/tests/HttpResponseMatcherTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest;
+
+use PHPUnit\Framework\TestCase;
+use Shopify\Clients\HttpResponse;
+
+class HttpResponseMatcherTest extends TestCase
+{
+    private array $successResponse = [
+        'products' => [
+            'title' => 'Test Product',
+            'amount' => 1,
+        ],
+    ];
+
+    public function testMatchFailsForIncorrectDataType()
+    {
+        $matcher = new HttpResponseMatcher();
+        $this->assertThat("incorrect data type", $this->logicalNot($matcher));
+    }
+
+
+    public function testMatchPassesIfAllParametersAreEqual()
+    {
+        $response = new HttpResponse(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            json_encode($this->successResponse)
+        );
+        $matcher = new HttpResponseMatcher(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            $this->successResponse
+        );
+        $this->assertThat($response, $matcher);
+    }
+
+    public function testMatchFailsIfAnyOfTheParametersIsNotEqual()
+    {
+        $response = new HttpResponse(
+            204,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            json_encode($this->successResponse)
+        );
+        $matcher = new HttpResponseMatcher(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            $this->successResponse
+        );
+
+        $this->assertThat($response, $this->logicalNot($matcher));
+
+        $response = new HttpResponse(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['totally differnt value']],
+            json_encode($this->successResponse)
+        );
+        $matcher = new HttpResponseMatcher(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            $this->successResponse
+        );
+        $this->assertThat($response, $this->logicalNot($matcher));
+
+        $response = new HttpResponse(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            json_encode($this->successResponse)
+        );
+        $matcher = new HttpResponseMatcher(
+            200,
+            ['Header-1' => ['ABCD'], 'Header-2' => ['DCBA']],
+            null
+        );
+        $this->assertThat($response, $this->logicalNot($matcher));
+    }
+}

--- a/tests/Webhooks/RegistryTest.php
+++ b/tests/Webhooks/RegistryTest.php
@@ -322,7 +322,7 @@ final class RegistryTest extends BaseTestCase
                 body: $this->checkQuery,
                 userAgent: "Shopify Admin API Library for PHP v",
                 headers: ['X-Shopify-Access-Token: real_token'],
-                response: $this->buildMockHttpResponse(403, "Unauthorized"),
+                response: $this->buildMockHttpResponse(403),
             ),
         ]);
 
@@ -353,7 +353,7 @@ final class RegistryTest extends BaseTestCase
                 body: $this->registerAddQuery,
                 userAgent: "Shopify Admin API Library for PHP v",
                 headers: ['X-Shopify-Access-Token: real_token'],
-                response: $this->buildMockHttpResponse(403, "Unauthorized"),
+                response: $this->buildMockHttpResponse(403),
             ),
         ]);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Use Standard HTTP response

### WHAT is this pull request doing?

- Replace `HttpResponse->getBody()` with `HttpResponse->getDecodedBody`. `getBody` returns a stream as per standard. `getDecodedBody` returns decoded json as an array, which was the previous behaviour of `getBody`

- Created `HttpResponseMatcher`. Using standard `assertEquals` to match response fails to match the body streams.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
