### PR TITLE
Clean up HTTP headers

### DIFF
--- a/src/Clients/HttpHeaders.php
+++ b/src/Clients/HttpHeaders.php
@@ -15,7 +15,12 @@ final class HttpHeaders
     public const X_SHOPIFY_HMAC = 'X-Shopify-Hmac-Sha256';
     public const X_SHOPIFY_TOPIC = 'X-Shopify-Topic';
     public const X_SHOPIFY_DOMAIN = 'X-Shopify-Shop-Domain';
-
+    public const X_SHOPIFY_API_DEPRECATED_REASON = 'X-Shopify-API-Deprecated-Reason';
+    public const PAGINATION_HEADER = 'Link';
+    public const CONTENT_TYPE = 'Content-Type';
+    public const CONTENT_LENGTH = 'Content-Length';
+    public const USER_AGENT = 'User-Agent';
+    public const RETRY_AFTER = 'Retry-After';
     private array $headerSet = [];
 
     /**

--- a/src/Clients/Rest.php
+++ b/src/Clients/Rest.php
@@ -76,9 +76,8 @@ class Rest extends Http
     private function getPageInfo(HttpResponse $response): ?PageInfo
     {
         $pageInfo = null;
-
-        if (array_key_exists('Link', $response->getHeaders())) {
-            $pageInfo = PageInfo::fromLinkHeader($response->getHeaders()['Link'][0]);
+        if ($response->hasHeader(HttpHeaders::PAGINATION_HEADER)) {
+            $pageInfo = PageInfo::fromLinkHeader($response->getHeaderLine(HttpHeaders::PAGINATION_HEADER));
         }
         return $pageInfo;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Use header methods on standard HTTP response instead of managing headers manually

### WHAT is this pull request doing?

Create constants for HTTP headers and move them into `HttpHeaders` class
## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
