### PR TITLE
Update Graphql proxy to work with Apollo client

### DIFF
--- a/src/Clients/Graphql.php
+++ b/src/Clients/Graphql.php
@@ -34,7 +34,7 @@ class Graphql
      *
      * @param string|array   $data         Query to be posted to endpoint
      * @param array          $query        Parameters on a query to be added to the URL
-     * @param array         &$extraHeaders Any extra headers to send along with the request
+     * @param array          $extraHeaders Any extra headers to send along with the request
      * @param int|null       $tries        How many times to attempt the request
      *
      * @return HttpResponse
@@ -44,7 +44,7 @@ class Graphql
     public function query(
         string | array $data,
         array $query = [],
-        array &$extraHeaders = [],
+        array $extraHeaders = [],
         ?int $tries = null
     ): HttpResponse {
         if (empty($data)) {
@@ -68,6 +68,40 @@ class Graphql
             headers: $extraHeaders,
             tries: $tries,
             query: $query,
+        );
+    }
+
+    /**
+     * Proxy string query to this client's domain.
+     *
+     * @param string   $data         Query to be posted to endpoint
+     * @param array    $extraHeaders Any extra headers to send along with the request
+     * @param int|null $tries        How many times to attempt the request
+     *
+     * @return \Shopify\Clients\HttpResponse
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \Shopify\Exception\MissingArgumentException
+     * @throws \Shopify\Exception\UninitializedContextException
+     */
+    public function proxy(
+        string $data,
+        array $extraHeaders = [],
+        ?int $tries = null
+    ): HttpResponse {
+        if (empty($data)) {
+            throw new MissingArgumentException('Query missing');
+        }
+
+        list($accessTokenHeader, $accessToken) = $this->getAccessTokenHeader();
+        $extraHeaders[$accessTokenHeader] = $accessToken;
+
+        return $this->client->post(
+            path: $this->getApiPath(),
+            body: $data,
+            dataType: Http::DATA_TYPE_JSON,
+            headers: $extraHeaders,
+            tries: $tries,
+            query: [],
         );
     }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -169,9 +169,11 @@ final class Utils
      * @param string $rawBody    The raw HTTP request payload
      *
      * @return HttpResponse
+     * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \Shopify\Exception\CookieNotFoundException
      * @throws \Shopify\Exception\MissingArgumentException
      * @throws \Shopify\Exception\SessionNotFoundException
+     * @throws \Shopify\Exception\UninitializedContextException
      */
     public static function graphqlProxy(array $rawHeaders, array $cookies, string $rawBody): HttpResponse
     {
@@ -182,8 +184,6 @@ final class Utils
 
         $client = new Graphql($session->getShop(), $session->getAccessToken());
 
-        // If the body is not JSON, we forward it as a string
-        $parsedBody = json_decode($rawBody, true) ?: $rawBody;
-        return $client->query(data: $parsedBody);
+        return $client->proxy(data: $rawBody);
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -275,7 +275,7 @@ final class UtilsTest extends BaseTestCase
                 url: "https://$this->domain/admin/api/" . Context::$API_VERSION . '/graphql.json',
                 method: 'POST',
                 headers: [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'Content-Length: ' . strlen($this->testGraphqlQuery),
                     'X-Shopify-Access-Token: token',
                 ],
@@ -312,7 +312,7 @@ final class UtilsTest extends BaseTestCase
                 url: "https://$this->domain/admin/api/" . Context::$API_VERSION . '/graphql.json',
                 method: 'POST',
                 headers: [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'Content-Length: ' . strlen($this->testGraphqlQuery),
                     'X-Shopify-Access-Token: token',
                 ],


### PR DESCRIPTION
### WHY are these changes introduced?
Fix an issue discovered in https://github.com/Shopify/shopify-app-php/pull/14

Query variables get transformed from a JSON object to an array.

- Requests coming from Apollo to the App come as a string for example: `{"variables":{},"query":"{\n  shop {\n    name\n    __typename\n  }\n}\n"}`
- In `Utils::graphqlProxy` that payload is decoded with the flag for associative array result `json_decode($rawBody, true)`
- When we try to re-encode the body again inside `GraphQ->query` it gets encoded as `{"variables":[],"query":"{\n  shop {\n    name\n    __typename\n  }\n}\n"}`

### WHAT is this pull request doing?

Creates a new method proxy that passes `rawBody` as is and sets `content-type` to `application/json`

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
