### PR TITLE
Add support to pubsub webhook delivery method

### DIFF
--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -62,15 +62,23 @@ After your handlers are loaded, you need to register which topics you want your 
 
 In your OAuth callback action, you can use the `Shopify\Webhooks\Registry::register` method to subscribe to any topic allowed by your app's scopes. This method can safely be called multiple times for a shop, as it will update existing webhooks if necessary.
 
+### EventBridge and PubSub Webhooks
+
+You can also register webhooks for delivery to Amazon EventBridge or Google Cloud Pub/Sub. In this case the `path` argument to `Registry::register` needs to be of a specific form.
+
+For EventBridge, the `path` must be the [ARN of the partner event source](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EventSource.html).
+
+For Pub/Sub, the `path` must be of the form `pubsub://[PROJECT-ID]:[PUB-SUB-TOPIC-ID]`.  For example, if you created a topic with id `red` in the project `blue`, then the value of `path` would be `pubsub://blue:red`.
+
 The parameters this method accepts are:
 
-| Parameter | Type | Required? | Default Value | Notes |
-| --- | --- | :---: | :---: | --- |
-| `path` | `string` | Yes | - | The URL path for the callback. If using EventBridge, this is the full resource address. |
-| `topic` | `string` | Yes | - | The topic to subscribe to. May be a string or a value from the Topics class. |
-| `shop` | `string` | Yes | - | The shop to use for requests. |
-| `accessToken` | `string` | Yes | - | The access token to use for requests. |
-| `deliveryMethod` | `string` | No | `Registry::DELIVERY_METHOD_HTTP` | The delivery method for this webhook. |
+| Parameter        | Type     | Required? |          Default Value           | Notes                                                                        |
+|:-----------------|:---------|:---------:|:--------------------------------:|:-----------------------------------------------------------------------------|
+| `path`           | `string` |    Yes    |                -                 | The URL path for the callback for HTTP delivery, EventBridge or Pub/Sub URLs |
+| `topic`          | `string` |    Yes    |                -                 | The topic to subscribe to. May be a string or a value from the Topics class. |
+| `shop`           | `string` |    Yes    |                -                 | The shop to use for requests.                                                |
+| `accessToken`    | `string` |    Yes    |                -                 | The access token to use for requests.                                        |
+| `deliveryMethod` | `string` |    No     | `Registry::DELIVERY_METHOD_HTTP` | The delivery method for this webhook.                                        |
 
 This method will return a `RegisterResponse` object, which holds the following data:
 

--- a/src/Webhooks/Delivery/EventBridge.php
+++ b/src/Webhooks/Delivery/EventBridge.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Shopify\Webhooks\Delivery;
+
+use Shopify\Context;
+use Shopify\Exception\InvalidArgumentException;
+use Shopify\Utils;
+use Shopify\Webhooks\DeliveryMethod;
+
+class EventBridge extends DeliveryMethod
+{
+
+    /**
+     * @throws \Shopify\Exception\InvalidArgumentException
+     */
+    public function __construct()
+    {
+        if (!Utils::isApiVersionCompatible('2020-07')) {
+            throw new InvalidArgumentException(
+                "EventBridge webhooks are not supported in API version " . Context::$API_VERSION
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCallbackAddress(string $path): string
+    {
+        return $path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parseCheckQueryResult(array $body): array
+    {
+        $edges = $body['data']['webhookSubscriptions']['edges'] ?? [];
+
+        $webhookId = null;
+        $currentAddress = null;
+        if (count($edges ?? [])) {
+            $node = $edges[0]['node'];
+            $webhookId = (string)$node['id'];
+            $currentAddress = $node['endpoint']['arn'];
+        }
+        return [$webhookId, $currentAddress];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildCheckQuery(string $topic): string
+    {
+        return <<<QUERY
+            {
+                webhookSubscriptions(first: 1, topics: $topic) {
+                    edges {
+                        node {
+                            id
+                            endpoint {
+                                __typename
+                                ... on WebhookEventBridgeEndpoint {
+                                    arn
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            QUERY;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMutationName(?string $webhookId): string
+    {
+        return $webhookId ? "eventBridgeWebhookSubscriptionUpdate" : "eventBridgeWebhookSubscriptionCreate";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function queryEndpoint(string $address): string
+    {
+        return "{arn: \"$address\"}";
+    }
+}

--- a/src/Webhooks/Delivery/HttpDelivery.php
+++ b/src/Webhooks/Delivery/HttpDelivery.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Shopify\Webhooks\Delivery;
+
+use Shopify\Context;
+use Shopify\Utils;
+use Shopify\Webhooks\DeliveryMethod;
+
+class HttpDelivery extends DeliveryMethod
+{
+    /**
+     * @inheritDoc
+     */
+    public function getCallbackAddress(string $path): string
+    {
+        return 'https://' . Context::$HOST_NAME . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * Builds a GraphQL query to check whether this topic is already registered for the shop.
+     *
+     * @param string $topic
+     *
+     * @return string
+     * @throws \Shopify\Exception\InvalidArgumentException
+     */
+    public function buildCheckQuery(string $topic): string
+    {
+        if (Utils::isApiVersionCompatible('2020-07')) {
+            return <<<QUERY
+            {
+                webhookSubscriptions(first: 1, topics: $topic) {
+                    edges {
+                        node {
+                            id
+                            endpoint {
+                                __typename
+                                ... on WebhookHttpEndpoint {
+                                    callbackUrl
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            QUERY;
+        } else {
+            return <<<LEGACY_QUERY
+            {
+                webhookSubscriptions(first: 1, topics: $topic) {
+                    edges {
+                        node {
+                            id
+                            callbackUrl
+                        }
+                    }
+                }
+            }
+            LEGACY_QUERY;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parseCheckQueryResult(array $body): array
+    {
+        $edges = $body['data']['webhookSubscriptions']['edges'] ?? [];
+        $webhookId = null;
+        $currentAddress = null;
+        if (count($edges ?? [])) {
+            $node = $edges[0]['node'];
+            $webhookId = (string)$node['id'];
+            if (array_key_exists('endpoint', $node)) {
+                $currentAddress = $node['endpoint']['callbackUrl'];
+            } else {
+                $currentAddress = $node['callbackUrl'];
+            }
+        }
+        return [$webhookId, $currentAddress];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMutationName(?string $webhookId): string
+    {
+        return $webhookId ? "webhookSubscriptionUpdate" : "webhookSubscriptionCreate";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function queryEndpoint(string $address): string
+    {
+        return "{callbackUrl: \"$address\"}";
+    }
+}

--- a/src/Webhooks/Delivery/PubSub.php
+++ b/src/Webhooks/Delivery/PubSub.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Shopify\Webhooks\Delivery;
+
+use Shopify\Context;
+use Shopify\Exception\InvalidArgumentException;
+use Shopify\Utils;
+use Shopify\Webhooks\DeliveryMethod;
+
+class PubSub extends DeliveryMethod
+{
+
+    /**
+     * @throws \Shopify\Exception\InvalidArgumentException
+     */
+    public function __construct()
+    {
+        if (!Utils::isApiVersionCompatible('2021-07')) {
+            throw new InvalidArgumentException(
+                "PubSub webhooks are not supported in API version " . Context::$API_VERSION
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCallbackAddress(string $path): string
+    {
+        return $path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parseCheckQueryResult(array $body): array
+    {
+        $edges = $body['data']['webhookSubscriptions']['edges'] ?? [];
+
+        $webhookId = null;
+        $currentAddress = null;
+        if (count($edges ?? [])) {
+            $node = $edges[0]['node'];
+
+            $webhookId = (string)$node['id'];
+            $currentAddress = "pubsub://" . $node['endpoint']['pubSubProject'] . ":" . $node['endpoint']['pubSubTopic'];
+        }
+        return [$webhookId, $currentAddress];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildCheckQuery(string $topic): string
+    {
+        return <<<QUERY
+            {
+                webhookSubscriptions(first: 1, topics: $topic) {
+                    edges {
+                        node {
+                            id
+                            endpoint {
+                                __typename
+                                ... on WebhookPubSubEndpoint {
+                                    pubSubProject
+                                    pubSubTopic
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            QUERY;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMutationName(?string $webhookId): string
+    {
+        return $webhookId ? "pubSubWebhookSubscriptionUpdate" : "pubSubWebhookSubscriptionCreate";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function queryEndpoint(string $address): string
+    {
+        $addressWithoutProtocol = explode("//", $address);
+        list($project, $topic) = explode(":", $addressWithoutProtocol[1]);
+        return "{pubSubProject: \"$project\", pubSubTopic: \"$topic\"}";
+    }
+}

--- a/src/Webhooks/DeliveryMethod.php
+++ b/src/Webhooks/DeliveryMethod.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Shopify\Webhooks;
+
+abstract class DeliveryMethod
+{
+    /**
+     * Builds the full address to be used for the webhook, depending on the delivery method.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    abstract public function getCallbackAddress(string $path): string;
+
+    /**
+     * Builds the mutation name to be used depending on the delivery method and webhook id.
+     *
+     * @param string|null $webhookId
+     *
+     * @return string
+     */
+    abstract protected function getMutationName(?string $webhookId): string;
+
+    /**
+     * Assembles a GraphQL query for registering a webhook.
+     *
+     * @param string $address
+     *
+     * @return string
+     */
+    abstract protected function queryEndpoint(string $address): string;
+
+    /**
+     * Builds a GraphQL query to check whether this topic is already registered for the shop.
+     *
+     * @param string $topic
+     *
+     * @return string
+     */
+    abstract public function buildCheckQuery(string $topic): string;
+
+    /**
+     * @param array $body
+     *
+     * @return array Array of the webhookId and current delivery address
+     */
+    abstract public function parseCheckQueryResult(array $body): array;
+
+    /**
+     * Assembles a GraphQL query for registering a webhook.
+     *
+     * @param string      $topic
+     * @param string      $callbackAddress
+     * @param string|null $webhookId
+     *
+     * @return string
+     */
+    public function buildRegisterQuery(
+        string $topic,
+        string $callbackAddress,
+        ?string $webhookId = null
+    ): string {
+        $mutationName = $this->getMutationName($webhookId);
+        $identifier = $webhookId ? "id: \"$webhookId\"" : "topic: $topic";
+        $webhookSubscriptionArgs = $this->queryEndpoint($callbackAddress);
+
+        return <<<QUERY
+        mutation webhookSubscription {
+            $mutationName($identifier, webhookSubscription: $webhookSubscriptionArgs) {
+                userErrors {
+                    field
+                    message
+                }
+                webhookSubscription {
+                    id
+                }
+            }
+        }
+        QUERY;
+    }
+
+    /**
+     * Checks if the given result was successful.
+     *
+     * @param array       $result
+     * @param string|null $webhookId
+     *
+     * @return bool
+     */
+    public function isSuccess(array $result, ?string $webhookId = null): bool
+    {
+        return !empty($result['data'][$this->getMutationName($webhookId)]['webhookSubscription']);
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Add support to pubsub webhook delivery method

### WHAT is this pull request doing?

Add `DELIVERY_METHOD_PUB_SUB`

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
