### PR TITLE
Add link to Packagist with install instructions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,9 @@ Before you start building your app, you'll need to perform the steps below.
 
 ## Install dependencies
 
-To use this library, you'll need to have PHP 8 installed in your server.
+To use this library, you'll need to have at least PHP 7.3 installed in your server.
+
+The library is available on [Packagist](https://packagist.org/packages/shopify/shopify-api`). You can add it to your project's Composer dependencies with `composer require shopify/shopify-api`.
 
 ## Set up the library
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ Before you start building your app, you'll need to perform the steps below.
 
 To use this library, you'll need to have at least PHP 7.3 installed in your server.
 
-The library is available on [Packagist](https://packagist.org/packages/shopify/shopify-api`). You can add it to your project's Composer dependencies with `composer require shopify/shopify-api`.
+The library is available on [Packagist](https://packagist.org/packages/shopify/shopify-api). You can add it to your project's Composer dependencies with `composer require shopify/shopify-api`.
 
 ## Set up the library
 


### PR DESCRIPTION
This PR adds a link to the library on Packagist, plus a Composer install command to copy and paste.

### WHY are these changes introduced?

Closes #98, assuming CodeIgniter 4. Previous versions did not have explicit Composer support, but there are a lot of resources for how to integrate Composer with previous CodeIgniter versions already available elsewhere.

### WHAT is this pull request doing?

Updating docs.
