### PR TITLE
Update session cookie expiration after OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - [#117](https://github.com/Shopify/shopify-php-api/pull/117) Handle float `Retry-After` headers
+- [#114](https://github.com/Shopify/shopify-php-api/pull/114) Update session cookie expiration after OAuth
 
 ### Added
 ### Fixed

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -15,7 +15,7 @@ Create a route for starting the OAuth method such as `/login`. In this route, th
 | `isOnline` | `bool` | Yes | - | `true` if the session is online and `false` otherwise. |
 | `setCookieFunction` | `callable` | No | - | An override function to set cookies in the HTTP request. In order to be framework-agnostic, the built-in `setcookie` method is applied. If that method does not work for your chosen framework, a function that sets cookies can be passed in. |
 
- An example of the custom set cookie function with Yii. Similar functions can be created for any frameworks that do not rely on the PHP `setcookie` function
+ An example of the custom set cookie function with Yii. Similar functions can be created for any frameworks that do not rely on the PHP `setcookie` function, but we **strongly recommend storing secure and signed cookies** in your app to help prevent session hijacking.
 ```php
 function () use (Shopify\Auth\OAuthCookie $cookie) {
     $cookies = Yii::$app->response->cookies;
@@ -41,6 +41,7 @@ To do that, you can call the `Shopify\Auth\OAuth::callback` method in the endpoi
 | --- | --- | :---: | :---: | --- |
 | `cookies` | `array` | Yes | - | HTTP request cookies, from which the OAuth session will be loaded. This must be a hash of `cookie name => value` pairs. The value will be cast to string so they may be objects that implement `toString`. |
 | `query` | `array` | Yes | - | The HTTP request URL query values. |
+| `setCookieFunction` | `callable` | No | - | An override function to set cookies in the HTTP request. In order to be framework-agnostic, the built-in `setcookie` method is applied. If that method does not work for your chosen framework, a function that sets cookies can be passed in. |
 
 If successful, this method will return a `Session` object, which is described [below](#the-session-object). Once the session is created, you can use [utility methods](./utils.md) to fetch it.
 

--- a/src/Auth/OAuthCookie.php
+++ b/src/Auth/OAuthCookie.php
@@ -13,7 +13,7 @@ class OAuthCookie
     private $value;
     /** @var string */
     private $name;
-    /** @var int */
+    /** @var int|null */
     private $expire = 0;
     /** @var bool */
     private $secure = true;
@@ -23,7 +23,7 @@ class OAuthCookie
     public function __construct(
         string $value,
         string $name,
-        int $expire = 0,
+        ?int $expire = 0,
         bool $secure = true,
         bool $httpOnly = true
     ) {
@@ -44,7 +44,7 @@ class OAuthCookie
         return $this->name;
     }
 
-    public function getExpire(): int
+    public function getExpire(): ?int
     {
         return $this->expire;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #112

Currently, after OAuth is completed, we're not updating the session cookie's expiration time to match the session, which means the session is lost after a minute.

### WHAT is this pull request doing?

Making sure we're also updating the cookie on the `callback` method for OAuth.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
