### PR TITLE
Handle float Retry-After headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [#117](https://github.com/Shopify/shopify-php-api/pull/117) Handle float `Retry-After` headers
+
 ### Added
 ### Fixed

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -201,7 +201,7 @@ class Http
                     ? $response->getHeaderLine(HttpHeaders::RETRY_AFTER)
                     : Context::$RETRY_TIME_IN_SECONDS;
 
-                usleep($retryAfter * 1000000);
+                usleep((int)($retryAfter * 1000000));
             } else {
                 break;
             }

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -269,6 +269,35 @@ final class HttpTest extends BaseTestCase
         $client->get('test/path');
     }
 
+    public function testRetryAfterCanBeFloat()
+    {
+        $this->mockTransportRequests([
+            new MockRequest(
+                // 1ms sleep time so we don't affect test run times
+                $this->buildMockHttpResponse(429, null, ['Retry-After' => 0.001]),
+                "https://$this->domain/test/path",
+                "GET",
+                "^Shopify Admin API Library for PHP v$this->version$",
+            ),
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $this->successResponse),
+                "https://$this->domain/test/path",
+                "GET",
+                null,
+                [],
+                null,
+                null,
+                true,
+                true,
+            ),
+        ]);
+
+        $client = new Http($this->domain);
+
+        $response = $client->get('test/path', [], [], 2);
+        $this->assertThat($response, new HttpResponseMatcher(200, [], $this->successResponse));
+    }
+
     public function testRetryLogicForAllRetriableCodes()
     {
         $this->mockTransportRequests([


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #115 

Our code was working under the assumption that the `Retry-After` header would always be an integer, but it can be a float at times.

### WHAT is this pull request doing?

Casting the float back to an integer after we convert it to microseconds, since at that point any remaining fractional value is irrelevant.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have updated the documentation for public APIs from the library (if applicable)
