### PR TITLE
Adding support for REST resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Run tests
         run: composer test
+
+      # Enable this after adding the resources
+      # - name: Run REST resource tests
+      #   run: composer test_rest_resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- [#139](https://github.com/Shopify/shopify-php-api/pull/139) Add support for REST resources
 - [#134](https://github.com/Shopify/shopify-php-api/pull/134) ⚠️ [Breaking] Add support for PHP 8.1 and remove 7.3 from the supported list, since it's no longer supported
 - [#136](https://github.com/Shopify/shopify-php-api/pull/136) Allow full paths in REST requests
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "psr/log": "^1.1",
         "firebase/php-jwt": "^5.2",
         "psr/http-client": "^1.0",
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "doctrine/inflector": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
@@ -44,7 +45,8 @@
         "mikey179/vfsstream": "^1.6"
     },
     "scripts": {
-        "test": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --color",
+        "test": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --color --testsuite default",
+        "test_rest_resources": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --color --testsuite rest_resources",
         "lint": "./vendor/bin/phpcs --standard=PSR12 src tests"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea45289cd352fea936d969655180bfbd",
+    "content-hash": "957efc6c16c094359b0566e765e1495a",
     "packages": [
         {
             "name": "brick/math",
@@ -65,6 +65,97 @@
                 }
             ],
             "time": "2021-08-15T20:50:18+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "vimeo/psalm": "^4.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T20:16:43+00:00"
         },
         {
             "name": "firebase/php-jwt",

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -6,9 +6,19 @@ You can read our [REST Admin API](https://shopify.dev/docs/admin-api/getting-sta
 
 ## Making your first REST request
 
-REST Admin API endpoints are organized by [resource](https://shopify.dev/docs/admin-api/rest/reference#selecting-apis-for-your-app) . You'll need to use different API endpoints depending on the service that your app provides.
+REST Admin API endpoints are organized by [resource](https://shopify.dev/docs/admin-api/rest/reference#selecting-apis-for-your-app) . You'll need to use different API endpoints depending on the service that your app provides. There are two different ways of doing that with this library:
+* [REST resources](#rest-resources)
+* [REST client](#rest-client)
 
-REST uses `get`, `post`, `put`, and `delete` requests to retrieve, create, update, and delete resources respectively.
+### REST resources
+
+REST resources are objects that represent the REST endpoints in the Admin API. This library provides classes for the endpoints in all supported versions of the API. We don't provide classes for the `unstable` version because it may change at any point, which would cause the resource classes to become outdated.
+
+The resource classes will provide methods for all endpoints described in [the REST reference docs](https://shopify.dev/api/admin-rest). Please see the references for how to use a specific resource.
+
+### REST client
+
+The REST client uses `get`, `post`, `put`, and `delete` requests to retrieve, create, update, and delete resources respectively.
 
 | Parameter | Type            | Required? | Default Value    | Notes                                            |
 |:----------|:----------------|:---------:|:----------------:|:-------------------------------------------------|

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,10 @@
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>
+            <exclude>tests/Rest/Admin*</exclude>
+        </testsuite>
+        <testsuite name="rest_resources">
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -163,11 +163,13 @@ class Http
 
         $client = Context::$HTTP_CLIENT_FACTORY->client();
 
+        $query = preg_replace("/%5B[0-9]+%5D/", "%5B%5D", http_build_query($query));
+
         $url = (new Uri())
             ->withScheme('https')
             ->withHost($this->domain)
             ->withPath($this->getRequestPath($path))
-            ->withQuery(http_build_query($query));
+            ->withQuery($query);
 
         $request = new Request($method, $url, $headers);
         $request = $request->withHeader(HttpHeaders::USER_AGENT, implode(' | ', $userAgentParts));

--- a/src/Exception/RestResourceException.php
+++ b/src/Exception/RestResourceException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+class RestResourceException extends ShopifyException
+{
+}

--- a/src/Exception/RestResourceRequestException.php
+++ b/src/Exception/RestResourceRequestException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+class RestResourceRequestException extends ShopifyException
+{
+    private int $statusCode;
+
+    public function __construct($message, $statusCode)
+    {
+        parent::__construct($message);
+        $this->statusCode = $statusCode;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Rest/Base.php
+++ b/src/Rest/Base.php
@@ -1,0 +1,384 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Rest;
+
+use Shopify\Auth\Session;
+use Shopify\Clients\Rest;
+use Shopify\Clients\RestResponse;
+use Doctrine\Inflector\InflectorFactory;
+use ReflectionClass;
+use Shopify\Exception\RestResourceException;
+use Shopify\Exception\RestResourceRequestException;
+
+abstract class Base
+{
+    public static ?array $NEXT_PAGE_QUERY = null;
+    public static ?array $PREV_PAGE_QUERY = null;
+
+    /** @var Base[] */
+    protected static array $HAS_ONE = [];
+
+    /** @var Base[] */
+    protected static array $HAS_MANY = [];
+
+    /** @var array[] */
+    protected static array $PATHS = [];
+
+    protected static string $PRIMARY_KEY = "id";
+    protected static ?string $CUSTOM_PREFIX = null;
+
+    private array $originalState;
+    private array $setProps;
+    protected Session $session;
+
+    public function __construct(Session $session, array $fromData = null)
+    {
+        $this->originalState = [];
+        $this->setProps = [];
+        $this->session = $session;
+
+        if (!empty($fromData)) {
+            self::setInstanceData($this, $fromData);
+        }
+    }
+
+    public function save($updateObject = false): void
+    {
+        $data = self::dataDiff($this->toArray(), $this->originalState);
+
+        $method = !empty($data[static::$PRIMARY_KEY]) ? "put" : "post";
+
+        $saveBody = [static::getJsonBodyName() => $data];
+        $response = self::request($method, $method, $this->session, [], [], $saveBody, $this);
+
+        if ($updateObject) {
+            $body = $response->getDecodedBody();
+
+            self::createInstance($body[$this->getJsonBodyName()], $this->session, $this);
+        }
+    }
+
+    public function saveAndUpdate(): void
+    {
+        $this->save(true);
+    }
+
+    public function __get(string $name)
+    {
+        if (!array_key_exists($name, $this->setProps) && in_array($name, $this->getProperties())) {
+            return null;
+        }
+
+        return $this->setProps[$name];
+    }
+
+    public function __set(string $name, $value): void
+    {
+        $this->setProperty($name, $value);
+    }
+
+    public static function getNextPageInfo()
+    {
+        return static::$NEXT_PAGE_QUERY;
+    }
+
+    public static function getPreviousPageInfo()
+    {
+        return static::$PREV_PAGE_QUERY;
+    }
+
+    protected static function getJsonBodyName(): string
+    {
+        $className = preg_replace("/^([A-z_0-9]+\\\)*([A-z_]+)/", "$2", static::class);
+        return strtolower(preg_replace("/([a-z])([A-Z])/", "$1_$2", $className));
+    }
+
+    /**
+     * @param string[]|int[] $ids
+     *
+     * @return static[]
+     */
+    protected static function baseFind(Session $session, array $ids = [], array $params = []): array
+    {
+        $response = self::request("get", "get", $session, $ids, $params);
+
+        static::$NEXT_PAGE_QUERY = static::$PREV_PAGE_QUERY = null;
+        $pageInfo = $response->getPageInfo();
+        if ($pageInfo) {
+            static::$NEXT_PAGE_QUERY = $pageInfo->hasNextPage() ? $pageInfo->getNextPageQuery() : null;
+            static::$PREV_PAGE_QUERY = $pageInfo->hasPreviousPage() ? $pageInfo->getPreviousPageQuery() : null;
+        }
+
+        return static::createInstancesFromResponse($response, $session);
+    }
+
+    /**
+     * @param static $entity
+     */
+    protected static function request(
+        string $httpMethod,
+        string $operation,
+        Session $session,
+        array $ids = [],
+        array $params = [],
+        array $body = [],
+        self $entity = null
+    ): RestResponse {
+        $path = static::getPath($httpMethod, $operation, $ids, $entity);
+
+        $client = new Rest($session->getShop(), $session->getAccessToken());
+
+        $params = array_filter($params);
+        switch ($httpMethod) {
+            case "get":
+                $response = $client->get($path, [], $params);
+                break;
+            case "post":
+                $response = $client->post($path, $body, [], $params);
+                break;
+            case "put":
+                $response = $client->put($path, $body, [], $params);
+                break;
+            case "delete":
+                $response = $client->delete($path, [], $params);
+                break;
+        }
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $message = "REST request failed";
+
+            $body = $response->getDecodedBody();
+            if (!empty($body["errors"])) {
+                $bodyErrors = json_encode($body["errors"]);
+                $message .= ": {$bodyErrors}";
+            }
+
+            throw new RestResourceRequestException($message, $statusCode);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string[]|int[] $ids
+     */
+    private static function getPath(
+        string $httpMethod,
+        string $operation,
+        array $ids,
+        self $entity = null
+    ): ?string {
+        $match = null;
+
+        $maxIds = -1;
+        foreach (static::$PATHS as $path) {
+            if ($httpMethod !== $path["http_method"] || $operation !== $path["operation"]) {
+                continue;
+            }
+
+            $urlIds = $ids;
+            foreach ($path["ids"] as $id) {
+                if ((!array_key_exists($id, $ids) || $ids[$id] === null) && $entity && $entity->$id) {
+                    $urlIds[$id] = $entity->$id;
+                }
+            }
+            $urlIds = array_filter($urlIds);
+
+            if (!empty(array_diff($path["ids"], array_keys($urlIds))) || count($path["ids"]) <= $maxIds) {
+                continue;
+            }
+
+            $maxIds = count($path["ids"]);
+            $match = preg_replace_callback(
+                '/(<([^>]+)>)/',
+                function ($matches) use ($urlIds) {
+                    return $urlIds[$matches[2]];
+                },
+                $path["path"]
+            );
+        }
+
+        if (empty($match)) {
+            throw new RestResourceException("Could not find a path for request");
+        }
+
+        if (static::$CUSTOM_PREFIX) {
+            $match = preg_replace("/^\/?/", "", static::$CUSTOM_PREFIX) . "/$match";
+        }
+        return $match;
+    }
+
+    /**
+     * @return static[]
+     */
+    private static function createInstancesFromResponse(RestResponse $response, Session $session): array
+    {
+        $objects = [];
+
+        $body = $response->getDecodedBody();
+        $className = static::getJsonBodyName();
+        $pluralClass = self::pluralize($className);
+
+        if (!empty($body)) {
+            if (array_key_exists($className, $body)) {
+                array_push($objects, self::createInstance($body[$className], $session));
+            } elseif (array_key_exists($pluralClass, $body)) {
+                foreach ($body[$pluralClass] as $entry) {
+                    array_push($objects, self::createInstance($entry, $session));
+                }
+            }
+        }
+
+        return $objects;
+    }
+
+    /**
+     * @return static
+     */
+    private static function createInstance(array $data, Session $session, &$instance = null)
+    {
+        $instance = $instance ?: new static($session);
+
+        if (!empty($data)) {
+            self::setInstanceData($instance, $data);
+        }
+
+        return $instance;
+    }
+
+    private static function isHasManyAttribute(string $property): bool
+    {
+        return array_key_exists($property, static::$HAS_MANY);
+    }
+
+    private static function isHasOneAttribute(string $property): bool
+    {
+        return array_key_exists($property, static::$HAS_ONE);
+    }
+
+    private static function pluralize(string $str): string
+    {
+        $inflector = InflectorFactory::create()->build();
+        return $inflector->pluralize($str);
+    }
+
+    private static function setInstanceData(self &$instance, array $data): void
+    {
+        $instance->originalState = [];
+
+        foreach ($instance->getProperties() as $prop) {
+            if (!array_key_exists($prop, $data)) {
+                continue;
+            }
+
+            if (self::isHasManyAttribute($prop)) {
+                $attrList = [];
+                if (!empty($data[$prop])) {
+                    foreach ($data[$prop] as $elementData) {
+                        array_push(
+                            $attrList,
+                            static::$HAS_MANY[$prop]::createInstance($elementData, $instance->session)
+                        );
+                    }
+                }
+
+                $instance->setProperty($prop, $attrList);
+            } elseif (self::isHasOneAttribute($prop)) {
+                if (!empty($data[$prop])) {
+                    $instance->setProperty(
+                        $prop,
+                        static::$HAS_ONE[$prop]::createInstance($data[$prop], $instance->session)
+                    );
+                }
+            } else {
+                $instance->setProperty($prop, $data[$prop]);
+                $instance->originalState[$prop] = $data[$prop];
+            }
+        }
+    }
+
+    private static function dataDiff(array $data1, array $data2): array
+    {
+        $diff = array();
+
+        foreach ($data1 as $key1 => $value1) {
+            if (array_key_exists($key1, $data2)) {
+                if (is_array($value1)) {
+                    $recursiveDiff = self::dataDiff($value1, $data2[$key1]);
+                    if (count($recursiveDiff)) {
+                        $diff[$key1] = $recursiveDiff;
+                    }
+                } else {
+                    if ($value1 != $data2[$key1]) {
+                        $diff[$key1] = $value1;
+                    }
+                }
+            } else {
+                $diff[$key1] = $value1;
+            }
+        }
+        return $diff;
+    }
+
+    private function setProperty(string $name, $value): void
+    {
+        $this->$name = $value;
+        $this->setProps[$name] = $value;
+    }
+
+    private function getProperties(): array
+    {
+        $reflection = new ReflectionClass(static::class);
+        $docBlock = $reflection->getDocComment();
+        $lines = explode("\n", $docBlock);
+
+        $props = [];
+        foreach ($lines as $line) {
+            preg_match("/[\s\*]+@property\s+[^\s]+\s+\\$(.*)/", $line, $matches);
+            if (empty($matches)) {
+                continue;
+            }
+
+            $props[] = $matches[1];
+        }
+
+        return array_unique(array_merge($props, array_keys($this->setProps)));
+    }
+
+    private function toArray(): array
+    {
+        $data = [];
+
+        foreach ($this->getProperties() as $prop) {
+            $includeProp = !empty($this->$prop) || array_key_exists($prop, $this->setProps);
+            if (self::isHasManyAttribute($prop)) {
+                if ($includeProp) {
+                    $data[$prop] = [];
+                    /** @var self $assoc */
+                    foreach ($this->$prop as $assoc) {
+                        if (empty($assoc) || is_array($assoc)) {
+                            array_push($data[$prop], $assoc);
+                        } else {
+                            array_push($data[$prop], $assoc->toArray());
+                        }
+                    }
+                }
+            } elseif (self::isHasOneAttribute($prop)) {
+                if ($includeProp) {
+                    if (empty($this->$prop) || is_array($this->$prop)) {
+                        $data[$prop] = $this->$prop;
+                    } else {
+                        $data[$prop] = $this->$prop->toArray();
+                    }
+                }
+            } elseif ($includeProp) {
+                $data[$prop] = $this->$prop;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/Clients/BaseRestResourceTest.php
+++ b/tests/Clients/BaseRestResourceTest.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Clients;
+
+use Shopify\Auth\Session;
+use Shopify\Context;
+use Shopify\Exception\RestResourceRequestException;
+use ShopifyTest\BaseTestCase;
+
+final class BaseRestResourceTest extends BaseTestCase
+{
+    use PaginationTestHelper;
+
+    private ?Session $session = null;
+    private string $prefix = "https://test-shop.myshopify.io/admin/api/unstable";
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Context::$API_VERSION = "unstable";
+
+        $this->session = new Session("1234", "test-shop.myshopify.io", true, "1234");
+        $this->session->setAccessToken("access-token");
+    }
+
+    public function testFindsResourceById()
+    {
+        $body = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "{$this->prefix}/fake_resources/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResource::find($this->session, 1);
+        $this->assertEquals([1, "attribute"], [$resource->id, $resource->attribute]);
+    }
+
+    public function testFindsWithParam()
+    {
+        $body = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "{$this->prefix}/fake_resources/1.json?param=value",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResource::find($this->session, 1, ["param" => "value"]);
+        $this->assertEquals([1, "attribute"], [$resource->id, $resource->attribute]);
+    }
+
+    public function testFindsResourceAndChildrenById()
+    {
+        $body = ["fake_resource" => [
+            "id" => 1,
+            "attribute" => "attribute1",
+            "has_one_attribute" => ["id" => 2, "attribute" => "attribute2"],
+            "has_many_attribute" => [
+                ["id" => 3, "attribute" => "attribute3"],
+            ],
+        ]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "{$this->prefix}/fake_resources/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResource::find($this->session, 1);
+        $this->assertEquals([1, "attribute1"], [$resource->id, $resource->attribute]);
+        $this->assertEquals(
+            [2, "attribute2"],
+            [$resource->has_one_attribute->id, $resource->has_one_attribute->attribute]
+        );
+        $this->assertEquals(
+            [3, "attribute3"],
+            [$resource->has_many_attribute[0]->id, $resource->has_many_attribute[0]->attribute]
+        );
+    }
+
+    public function testFindsResourceWithEmptyChildren()
+    {
+        $body = ["fake_resource" => [
+            "id" => 1,
+            "attribute" => "attribute1",
+            "has_one_attribute" => null,
+            "has_many_attribute" => null,
+        ]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "{$this->prefix}/fake_resources/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResource::find($this->session, 1);
+        $this->assertEquals([1, "attribute1"], [$resource->id, $resource->attribute]);
+        $this->assertNull($resource->has_one_attribute);
+        $this->assertEmpty($resource->has_many_attribute);
+    }
+
+    public function testFailsOnFindingNonexistentResourceById()
+    {
+        $body = ["errors" => "Not found"];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(404, $body),
+                "{$this->prefix}/fake_resources/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $this->expectException(RestResourceRequestException::class);
+        FakeResource::find($this->session, 1);
+    }
+
+    public function testFindsAllResources()
+    {
+        $body = ["fake_resources" => [
+            ["id" => 1, "attribute" => "attribute1"],
+            ["id" => 2, "attribute" => "attribute2"],
+        ]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "{$this->prefix}/fake_resources.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resources = FakeResource::all($this->session);
+        $this->assertEquals([1, "attribute1"], [$resources[0]->id, $resources[0]->attribute]);
+        $this->assertEquals([2, "attribute2"], [$resources[1]->id, $resources[1]->attribute]);
+    }
+
+    public function testSaves()
+    {
+        $requestBody = ["fake_resource" => ["attribute" => "attribute"]];
+        $responseBody = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $responseBody),
+                "{$this->prefix}/fake_resources.json",
+                "POST",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($requestBody)
+            ),
+        ]);
+
+        $resource = new FakeResource($this->session);
+        $resource->attribute = "attribute";
+
+        $resource->save();
+        $this->assertNull($resource->id);
+    }
+
+    public function testSavesAndUpdates()
+    {
+        $requestBody = ["fake_resource" => ["attribute" => "attribute"]];
+        $responseBody = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $responseBody),
+                "{$this->prefix}/fake_resources.json",
+                "POST",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($requestBody)
+            ),
+        ]);
+
+        $resource = new FakeResource($this->session);
+        $resource->attribute = "attribute";
+
+        $resource->saveAndUpdate();
+        $this->assertEquals(1, $resource->id);
+    }
+
+    public function testSavesExistingResource()
+    {
+        $requestBody = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+        $responseBody = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $responseBody),
+                "{$this->prefix}/fake_resources/1.json",
+                "PUT",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($requestBody)
+            ),
+        ]);
+
+        $resource = new FakeResource($this->session);
+        $resource->id = 1;
+        $resource->attribute = "attribute";
+
+        $resource->save();
+    }
+
+    public function testSavesWithChildren()
+    {
+        $requestBody = ["fake_resource" => [
+            "id" => 1,
+            "has_one_attribute" => ["attribute" => "attribute1"],
+            "has_many_attribute" => [["attribute" => "attribute2"]],
+        ]];
+        $responseBody = ["fake_resource" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $responseBody),
+                "{$this->prefix}/fake_resources/1.json",
+                "PUT",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($requestBody)
+            ),
+        ]);
+
+        $child1 = new FakeResource($this->session);
+        $child1->attribute = "attribute1";
+
+        $child2 = new FakeResource($this->session);
+        $child2->attribute = "attribute2";
+
+        $resource = new FakeResource($this->session);
+        $resource->id = 1;
+        $resource->has_one_attribute = $child1;
+        $resource->has_many_attribute = [$child2];
+
+        $resource->save();
+    }
+
+    public function testSavesWithUnknownAttribute()
+    {
+        $body = ["fake_resource" => ["unknown" => "some-value"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, ""),
+                "{$this->prefix}/fake_resources.json",
+                "POST",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($body)
+            ),
+        ]);
+
+        $resource = new FakeResource($this->session);
+        $resource->unknown = "some-value";
+
+        $resource->save();
+    }
+
+    public function testSavesWithForcedNullValue()
+    {
+        $body = ["fake_resource" => ["id" => 1, "has_one_attribute" => null]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, ""),
+                "{$this->prefix}/fake_resources/1.json",
+                "PUT",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+                json_encode($body)
+            ),
+        ]);
+
+        $resource = new FakeResource($this->session);
+        $resource->id = 1;
+        $resource->has_one_attribute = null;
+
+        $resource->save();
+    }
+
+    public function testDeletesExistingResource()
+    {
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, ""),
+                "{$this->prefix}/fake_resources/1.json",
+                "DELETE",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        FakeResource::delete($this->session, 1);
+    }
+
+    public function testDeletesOtherResource()
+    {
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, ""),
+                "{$this->prefix}/other_resources/2/fake_resources/1.json",
+                "DELETE",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        FakeResource::delete($this->session, 1, array("other_resource_id" => 2));
+    }
+
+    public function testFailsDeletingNonexistentResource()
+    {
+        $body = ["errors" => "Not found"];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(404, $body),
+                "{$this->prefix}/fake_resources/2.json",
+                "DELETE",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $this->expectException(RestResourceRequestException::class);
+        FakeResource::delete($this->session, 2);
+    }
+
+    public function testMakesCustomRequests()
+    {
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, json_encode(["test body"])),
+                "{$this->prefix}/other_resources/2/fake_resources/1/custom.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $response = FakeResource::custom($this->session, 1, array("other_resource_id" => 2));
+        $this->assertEquals(["test body"], $response);
+    }
+
+    public function testPagination()
+    {
+        $body = ["fake_resources" => []];
+
+        $firstPaginationHeader = $this->getProductsLinkHeader(null, "page-info");
+        $secondPaginationHeader = $this->getProductsLinkHeader("page-info2", null);
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(
+                    200,
+                    json_encode($body),
+                    ["Link" => $firstPaginationHeader]
+                ),
+                "{$this->prefix}/fake_resources.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+            new MockRequest(
+                $this->buildMockHttpResponse(
+                    200,
+                    json_encode($body),
+                    ["Link" => $secondPaginationHeader]
+                ),
+                "{$this->prefix}/fake_resources.json?limit=10&fields=test1%2Ctest2&page_info=page-info",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+            new MockRequest(
+                $this->buildMockHttpResponse(200, json_encode($body)),
+                "{$this->prefix}/fake_resources.json?limit=10&fields=test1%2Ctest2&page_info=page-info2",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        FakeResource::all($this->session);
+        $this->assertEquals(
+            ["page_info" => "page-info", "limit" => "10", "fields" => "test1,test2"],
+            FakeResource::$NEXT_PAGE_QUERY
+        );
+        $this->assertNull(FakeResource::$PREV_PAGE_QUERY);
+
+        FakeResource::all($this->session, FakeResource::$NEXT_PAGE_QUERY);
+        $this->assertNull(FakeResource::$NEXT_PAGE_QUERY);
+        $this->assertEquals(
+            ["page_info" => "page-info2", "limit" => "10", "fields" => "test1,test2"],
+            FakeResource::$PREV_PAGE_QUERY
+        );
+
+        FakeResource::all($this->session, FakeResource::$PREV_PAGE_QUERY);
+        $this->assertNull(FakeResource::$NEXT_PAGE_QUERY);
+        $this->assertNull(FakeResource::$PREV_PAGE_QUERY);
+    }
+
+    public function testAllowsCustomPrefixes()
+    {
+        $body = ["fake_resource_with_custom_prefix" => ["id" => 1, "attribute" => "attribute"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $body),
+                "https://test-shop.myshopify.io/admin/custom_prefix/fake_resource_with_custom_prefix/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResourceWithCustomPrefix::find($this->session, 1);
+        $this->assertEquals([1, "attribute"], [$resource->id, $resource->attribute]);
+    }
+}

--- a/tests/Clients/FakeResource.php
+++ b/tests/Clients/FakeResource.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Clients;
+
+use Shopify\Auth\Session;
+use Shopify\Rest\Base;
+
+/**
+ * @property int $id
+ * @property string $attribute
+ * @property FakeResource $has_one_attribute
+ * @property FakeResource[] $has_many_attribute
+ * @property int $other_resource_id
+ */
+final class FakeResource extends Base
+{
+    protected static array $HAS_ONE = [
+        "has_one_attribute" => FakeResource::class,
+    ];
+
+    protected static array $HAS_MANY = [
+        "has_many_attribute" => FakeResource::class,
+    ];
+
+    protected static array $PATHS = [
+        ["http_method" => "get", "operation" => "get", "ids" => [], "path" => "fake_resources.json"],
+        ["http_method" => "post", "operation" => "post", "ids" => [], "path" => "fake_resources.json"],
+        ["http_method" => "get", "operation" => "get", "ids" => ["id"], "path" => "fake_resources/<id>.json"],
+        ["http_method" => "put", "operation" => "put", "ids" => ["id"], "path" => "fake_resources/<id>.json"],
+        ["http_method" => "delete", "operation" => "delete", "ids" => ["id"], "path" => "fake_resources/<id>.json"],
+        [
+            "http_method" => "get", "operation" => "custom", "ids" => ["other_resource_id", "id"],
+            "path" => "other_resources/<other_resource_id>/fake_resources/<id>/custom.json",
+        ],
+        [
+            "http_method" => "delete", "operation" => "delete", "ids" => ["other_resource_id", "id"],
+            "path" => "other_resources/<other_resource_id>/fake_resources/<id>.json",
+        ],
+    ];
+
+    public static function find(Session $session, int $id, array $params = []): FakeResource
+    {
+        $result = parent::baseFind($session, ["id" => $id], $params);
+        return !empty($result) ? $result[0] : null;
+    }
+
+    /**
+     * @return FakeResource[]
+     */
+    public static function all(Session $session, array $params = []): array
+    {
+        return parent::baseFind($session, [], $params);
+    }
+
+    public static function delete(Session $session, int $id, array $otherIds = [])
+    {
+        parent::request("delete", "delete", $session, array_merge(["id" => $id], $otherIds));
+    }
+
+    public static function custom(Session $session, int $id, array $otherIds = []): array
+    {
+        return parent::request("get", "custom", $session, array_merge(["id" => $id], $otherIds))->getDecodedBody();
+    }
+}

--- a/tests/Clients/FakeResourceWithCustomPrefix.php
+++ b/tests/Clients/FakeResourceWithCustomPrefix.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShopifyTest\Clients;
+
+use Shopify\Auth\Session;
+use Shopify\Rest\Base;
+
+/**
+ * @property int $id
+ * @property string $attribute
+ */
+final class FakeResourceWithCustomPrefix extends Base
+{
+    /** @var Base[] */
+    protected static array $HAS_ONE = [];
+
+    /** @var Base[] */
+    protected static array $HAS_MANY = [];
+
+    /** @var array[] */
+    protected static array $PATHS = [
+        [
+            "http_method" => "get", "operation" => "get", "ids" => ["id"],
+            "path" => "fake_resource_with_custom_prefix/<id>.json"
+        ],
+    ];
+
+    protected static ?string $CUSTOM_PREFIX = "/admin/custom_prefix";
+
+    public static function find(Session $session, int $id)
+    {
+        $result = parent::baseFind($session, ["id" => $id]);
+        return !empty($result) ? $result[0] : null;
+    }
+}

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -69,6 +69,31 @@ final class HttpTest extends BaseTestCase
         $this->assertThat($response, new HttpResponseMatcher(200, [], $this->successResponse));
     }
 
+    public function testGetRequestWithArrayInQuery()
+    {
+        $headers = ['X-Test-Header' => 'test_value'];
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, $this->successResponse),
+                "https://$this->domain/test/path?array[]=value&hash[key1]=value1&hash[key2]=value2",
+                "GET",
+                "^Shopify Admin API Library for PHP v$this->version$",
+                ['X-Test-Header: test_value'],
+                null,
+                null,
+                false,
+            ),
+        ]);
+
+        $client = new Http($this->domain);
+        $response = $client->get(
+            'test/path',
+            $headers,
+            ["array" => ["value"], "hash" => ["key1" => "value1", "key2" => "value2"]]
+        );
+        $this->assertThat($response, new HttpResponseMatcher(200, [], $this->successResponse));
+    }
+
     public function testPostRequest()
     {
         $headers = ['X-Test-Header' => 'test_value'];


### PR DESCRIPTION
### WHY are these changes introduced?

We want to support creating classes that encapsulate the Admin API's REST resources, to make it easier for apps to interact with that API in an OO way.

### WHAT is this pull request doing?

Creating a "base" REST resource which provides all of the functionality classes would need to be able to map API calls to specific objects.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have updated the documentation for public APIs from the library (if applicable)
