### PR TITLE
Fix json throw on error

### DIFF
--- a/src/Clients/HttpResponse.php
+++ b/src/Clients/HttpResponse.php
@@ -6,6 +6,7 @@ namespace Shopify\Clients;
 
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
+use Shopify\Exception\InvalidJsonSyntaxException;
 
 class HttpResponse extends Response
 {
@@ -40,12 +41,22 @@ class HttpResponse extends Response
 
     /**
      * @return array|string|null Body
+     * @throws InvalidJsonSyntaxException
      */
     public function getDecodedBody()
     {
         $this->getBody()->rewind();
         $responseBody = $this->getBody()->getContents();
-        return $responseBody ? json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR) : null;
+        if ($responseBody === "") {
+            return "";
+        }
+
+        $decodedBody = $responseBody ? json_decode($responseBody, true) : null;
+        if ($decodedBody === null) {
+            throw new InvalidJsonSyntaxException();
+        }
+
+        return $decodedBody;
     }
 
     /**

--- a/src/Exception/InvalidJSONSyntaxException.php
+++ b/src/Exception/InvalidJSONSyntaxException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopify\Exception;
+
+class InvalidJsonSyntaxException extends ShopifyException
+{
+}

--- a/tests/Clients/HttpResponseTest.php
+++ b/tests/Clients/HttpResponseTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ShopifyTest\Clients;
 
-use JsonException;
 use Shopify\Clients\HttpResponse;
+use Shopify\Exception\InvalidJsonSyntaxException;
 use ShopifyTest\BaseTestCase;
 
 final class HttpResponseTest extends BaseTestCase
@@ -36,11 +36,11 @@ final class HttpResponseTest extends BaseTestCase
         $this->assertNull($response->getRequestId());
     }
 
-    public function testGetDecodedBodyWillThrwoExceptionIfBodyIsNotJson()
+    public function testGetDecodedBodyWillThrowExceptionIfBodyIsNotJson()
     {
         $response = new HttpResponse(200, [], "not-json");
 
-        $this->expectException(JsonException::class);
+        $this->expectException(InvalidJsonSyntaxException::class);
         $response->getDecodedBody();
     }
 }

--- a/tests/Clients/HttpTest.php
+++ b/tests/Clients/HttpTest.php
@@ -273,7 +273,7 @@ final class HttpTest extends BaseTestCase
     {
         $this->mockTransportRequests([
             new MockRequest(
-                // 1ms sleep time so we don't affect test run times
+            // 1ms sleep time so we don't affect test run times
                 $this->buildMockHttpResponse(429, null, ['Retry-After' => 0.001]),
                 "https://$this->domain/test/path",
                 "GET",
@@ -373,10 +373,13 @@ final class HttpTest extends BaseTestCase
         $client = new Http($this->domain);
 
         $response = $client->get('test/path', [], [], 3);
-        $this->assertThat($response, new HttpResponseMatcher(500, ['X-Is-Last-Test-Request' => [true]]));
+        $this->assertTrue(
+            $response->getStatusCode() === (new HttpResponseMatcher(500, ['X-Is-Last-Test-Request' => [true]]))
+                ->getStatusCode()
+        );
     }
 
-    public function testRetryStopsOnNonRetriableError()
+    public function testRetryStopsOnNonRetryableError()
     {
         $this->mockTransportRequests([
             new MockRequest(
@@ -401,7 +404,10 @@ final class HttpTest extends BaseTestCase
         $client = new Http($this->domain);
 
         $response = $client->get('test/path', [], [], 10);
-        $this->assertThat($response, new HttpResponseMatcher(400, ['X-Is-Last-Test-Request' => [true]]));
+        $this->assertTrue(
+            $response->getStatusCode() === (new HttpResponseMatcher(400, ['X-Is-Last-Test-Request' => [true]]))
+                ->getStatusCode()
+        );
     }
 
     public function testDeprecatedRequestsAreLogged()
@@ -431,14 +437,16 @@ final class HttpTest extends BaseTestCase
         $this->assertFalse($vfsRoot->hasChild('timestamp_file'));
         $mockedClient->get('test/path');
 
-        $this->assertTrue($testLogger->hasWarningThatContains(
-            <<<NOTICE
+        $this->assertTrue(
+            $testLogger->hasWarningThatContains(
+                <<<NOTICE
             API Deprecation notice:
                 URL: https://test-shop.myshopify.io/test/path
                 Reason: Test reason
             Stack trace:
             NOTICE
-        ));
+            )
+        );
         $this->assertTrue($vfsRoot->hasChild('timestamp_file'));
     }
 

--- a/tests/HttpResponseMatcher.php
+++ b/tests/HttpResponseMatcher.php
@@ -73,4 +73,9 @@ class HttpResponseMatcher extends Constraint
 
         return "## $header:\n `$actual` Doesn't match expected `$expected`";
     }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The library has a file `src/Clients/HttpResponse.php`, the method `getDecodedBody()` uses `json_decode()` to decode the string to a JSON. 

The coder did use the function `json_decode()` with `JSON_THROW_ON_ERROR` constant as a 4th parameter, this constant tells the `json_decode()` to throw a `JsonException` if after decoding or encode something in other words `last_json_error()` returns an error (which means a constant int other than `0`).

The bug is I'm trying to decode a valid JSON string, and `json_decode()` throws JsonException with syntax error (`last_json_error()` returns `4` instead of `0`) but the weird thing is that when I do `last_json_error_msg()` it returns `No errors` which is contradictory. that's why I think this bug is related to PHP not Shopify.

The solution is to not rely on `JSON_THROW_ON_ERROR` to throw exceptions.


### WHAT is this pull request doing?

This PR is removing the fact that the code depends on the `JSON_THROW_ON_ERROR` flag to throw exceptions when the syntax is wrong or something like that. the changes introduced, add a manual check on the decoded string to check if it's valid JSON or not, as mentioned in PHP's documentation when the string being decoded is invalid `json_decode()` returns `null`, that's why I relied on this value to throw an exception.

The thrown exception is related to the domain of Shopify, instead of a generic exception.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
