### PR TITLE
Fixing autoloading issues

### DIFF
--- a/src/rest_resource_autoloader.php
+++ b/src/rest_resource_autoloader.php
@@ -4,6 +4,7 @@
 
 use Composer\Autoload\ClassLoader;
 use Shopify\Context;
+use Shopify\Exception\ShopifyException;
 
 class RestResourceAutoloader
 {
@@ -27,13 +28,16 @@ class RestResourceAutoloader
                 if ($defaultClass = $this->loader->loadClass($name)) {
                     return $defaultClass;
                 } else {
+                    $folderName = "Admin" . ucfirst(str_replace("-", "_", Context::$API_VERSION));
+                    if (!file_exists(__DIR__ . "/Rest/$folderName")) {
+                        throw new ShopifyException(
+                            "This version of the Shopify library does not provide REST resources for API version " .
+                                "'" . Context::$API_VERSION . "'"
+                        );
+                    }
+
                     // If we failed to autoload the class, let's see if it's not a resource
-                    $name = implode("\\", [
-                        $parts[0],
-                        $parts[1],
-                        "Admin" . ucfirst(str_replace("-", "_", Context::$API_VERSION)),
-                        $parts[2],
-                    ]);
+                    $name = implode("\\", [$parts[0], $parts[1], $folderName, $parts[2]]);
                 }
             }
         }
@@ -42,6 +46,6 @@ class RestResourceAutoloader
     }
 }
 
-$loader = require 'vendor/autoload.php';
+$loader = require __DIR__ .  '/../vendor/autoload.php';
 $loader->unregister();
 spl_autoload_register(array(new RestResourceAutoloader($loader), 'loadClass'));


### PR DESCRIPTION
This PR fixes a couple of issues with the custom autoloading for REST resources:
- we were lacking a proper error message when an app attempts to load a resource that doesn't exist for the current context version
- we were relying on a relative path that broke when the library was installed elsewhere