### PR TITLE
Properly handle unset fields in base resource

### DIFF
--- a/src/Rest/Base.php
+++ b/src/Rest/Base.php
@@ -67,11 +67,7 @@ abstract class Base
 
     public function __get(string $name)
     {
-        if (!array_key_exists($name, $this->setProps) && in_array($name, $this->getProperties())) {
-            return null;
-        }
-
-        return $this->setProps[$name];
+        return array_key_exists($name, $this->setProps) ? $this->setProps[$name] : null;
     }
 
     public function __set(string $name, $value): void


### PR DESCRIPTION
### WHY are these changes introduced?

In the base resource, when we tried to retrieve a property that hadn't been set, there was a scenario where we would end up throwing an error by trying to access a property that hand't been set.

### WHAT is this pull request doing?

Simply making sure we don't throw, but instead return a `null` when trying to get a property that hadn't been set, to properly handle dynamic properties.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
