### PR TITLE
Load unknown attributes from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - [#168](https://github.com/Shopify/shopify-php-api/pull/168) Allow REST resources to configure a deny list of attributes to be excluded when saving
+- [#169](https://github.com/Shopify/shopify-php-api/pull/169) Allow loading dynamic fields returned by the API, and fix an issue when loading object arrays from API response data
 
 ## v2.0.0 - 2022-04-04
 

--- a/tests/Clients/BaseRestResourceTest.php
+++ b/tests/Clients/BaseRestResourceTest.php
@@ -264,6 +264,27 @@ final class BaseRestResourceTest extends BaseTestCase
         $resource->save();
     }
 
+    public function testLoadsUnknownAttribute()
+    {
+        $body = ["fake_resource" => ["attribute" => "value", "unknown?" => "some-value"]];
+
+        $this->mockTransportRequests([
+            new MockRequest(
+                $this->buildMockHttpResponse(200, json_encode($body)),
+                "{$this->prefix}/fake_resources/1.json",
+                "GET",
+                null,
+                ["X-Shopify-Access-Token: access-token"],
+            ),
+        ]);
+
+        $resource = FakeResource::find($this->session, 1);
+
+        $this->assertEquals("value", $resource->attribute);
+        $this->assertEquals("some-value", $resource->{"unknown?"});
+        $this->assertEquals("some-value", $resource->toArray()["unknown?"]);
+    }
+
     public function testSavesWithUnknownAttribute()
     {
         $body = ["fake_resource" => ["unknown" => "some-value"]];


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes, the API will send back data that's not exactly as documented, such as the `optionX` fields in products / variants - those are documented as `option`, but they dynamically accept any number of options.

The current code only accepts fields that are in the "expected" set when loading API data, but in cases like the above, we should just take whatever the API is sending our way.

### WHAT is this pull request doing?

Taking in any fields we receive from the API so we can cope with the above case, and making sure those fields get included in the data we send back.

Also, while fixing this, I noticed we were not properly handling the

```
{ resource => [{field1 => value1}] }
```

API response case properly (that is essentially an array of objects, but the data name is singular). We now properly detect that case when loading the data, and create the appropriate objects.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
