### PR TITLE
Fix test deprecation warning on PHP 8.1

### DIFF
--- a/tests/HttpRequestMatcher.php
+++ b/tests/HttpRequestMatcher.php
@@ -157,15 +157,15 @@ class HttpRequestMatcher extends Constraint
         $contents = $request->getBody()->getContents();
 
         $this->bodyDiff = $this->diffBody(
-            json_decode($this->body, true) ?: $this->body,
-            json_decode($contents, true) ?: $contents
+            json_decode((string)$this->body, true) ?: $this->body,
+            json_decode((string)$contents, true) ?: $contents
         );
 
         // If the diff is empty and we're looking for identical bodies, invert the diff to ensure it's still empty
         if ($this->identicalBody && empty($this->bodyDiff)) {
             $this->bodyDiff = $this->diffBody(
-                json_decode($contents, true) ?: $contents,
-                json_decode($this->body, true) ?: $this->body
+                json_decode((string)$contents, true) ?: $contents,
+                json_decode((string)$this->body, true) ?: $this->body
             );
         }
     }


### PR DESCRIPTION
### WHY are these changes introduced?

We got this error when running the tests on PHP 8.1:

```
PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /Users/paulo/src/github.com/Shopify/shopify-php-api/tests/HttpRequestMatcher.php on line 1609
```

This happens because sometimes we pass in null bodies, and the assumption before was that it would properly decode those.

### WHAT is this pull request doing?

This is only used for tests, so we do want the empty body in some cases. This just fixes the checker to cast nulls into a string to avoid the warning.