### PR TITLE
Default cookie setter in OAuth is not setting samesite = None #352

### DIFF
--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -351,21 +351,27 @@ class OAuth
             $cookieSet = setcookie(
                 $signatureCookie->getName(),
                 $signatureCookie->getValue(),
-                $signatureCookie->getExpire(),
-                "",
-                "",
-                $signatureCookie->isSecure(),
-                $signatureCookie->isHttpOnly(),
+                [
+                    'expires' => $signatureCookie->getExpire(),
+                    'path' => "",
+                    'domain' => "",
+                    'secure' => $signatureCookie->isSecure(),
+                    'httponly' => $signatureCookie->isHttpOnly(),
+                    'samesite' => "none"
+                ],
             );
 
             $cookieSet = $cookieSet && setcookie(
                 $cookie->getName(),
                 $cookie->getValue(),
-                $cookie->getExpire(),
-                "",
-                "",
-                $cookie->isSecure(),
-                $cookie->isHttpOnly(),
+                [
+                    'expires' => $signatureCookie->getExpire(),
+                    'path' => "",
+                    'domain' => "",
+                    'secure' => $signatureCookie->isSecure(),
+                    'httponly' => $signatureCookie->isHttpOnly(),
+                    'samesite' => "none"
+                ],
             );
             // @codeCoverageIgnoreEnd
         }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #352 

For context read the issue I created.

### WHAT is this pull request doing?

Basically sets samesite=none for cookies created in OAuth2.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
