### PR TITLE
Remove application/graphql as a content type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [#379](https://github.com/Shopify/shopify-api-php/pull/379) [Patch] Fix GraphQL `Content-Type` header to be `application/json`
+
 ## v5.7.0 - 2024-10-22
 - [#371](https://github.com/Shopify/shopify-api-php/pull/371) [Minor] Remove API version validation to allow more flexibility of API version. And add support for 2024-10 API version
 - [#370](https://github.com/Shopify/shopify-api-php/pull/370) [Patch] Fix params set to zero being removed from request payload

--- a/src/Clients/Graphql.php
+++ b/src/Clients/Graphql.php
@@ -60,10 +60,7 @@ class Graphql
         $extraHeaders[$accessTokenHeader] = $accessToken;
 
         if (is_array($data)) {
-            $dataType = Http::DATA_TYPE_JSON;
             $data = json_encode($data);
-        } else {
-            $dataType = Http::DATA_TYPE_GRAPHQL;
         }
 
         return $this->client->post(
@@ -72,7 +69,6 @@ class Graphql
             $extraHeaders,
             $query,
             $tries,
-            $dataType,
         );
     }
 

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -20,7 +20,6 @@ class Http
     public const METHOD_DELETE = 'DELETE';
 
     public const DATA_TYPE_JSON = 'application/json';
-    public const DATA_TYPE_GRAPHQL = 'application/graphql';
 
     private const RETRIABLE_STATUS_CODES = [429, 500];
     private const DEPRECATION_ALERT_SECONDS = 3600;

--- a/tests/Clients/GraphqlTest.php
+++ b/tests/Clients/GraphqlTest.php
@@ -101,7 +101,7 @@ final class GraphqlTest extends BaseTestCase
                 'POST',
                 "Shopify Admin API Library for PHP v$this->version",
                 [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'Content-Length: ' . strlen($this->testQueryString),
                     'X-Shopify-Access-Token: token'
                 ],
@@ -182,7 +182,7 @@ final class GraphqlTest extends BaseTestCase
                 'POST',
                 "Shopify Admin API Library for PHP v$this->version",
                 [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'Content-Length: ' . strlen($this->testQueryString),
                     'Extra-Extra: hear_all_about_it',
                     'X-Shopify-Access-Token: token'

--- a/tests/Clients/StorefrontTest.php
+++ b/tests/Clients/StorefrontTest.php
@@ -38,7 +38,7 @@ final class StorefrontTest extends BaseTestCase
                 'POST',
                 null,
                 [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'X-Shopify-Storefront-Access-Token: test_token',
                 ],
                 $this->query,
@@ -65,7 +65,7 @@ final class StorefrontTest extends BaseTestCase
                 'POST',
                 null,
                 [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'X-Shopify-Storefront-Access-Token: private_token',
                 ],
                 $this->query,
@@ -91,7 +91,7 @@ final class StorefrontTest extends BaseTestCase
                 'POST',
                 null,
                 [
-                    'Content-Type: application/graphql',
+                    'Content-Type: application/json',
                     'X-Shopify-Storefront-Access-Token: test_token',
                 ],
                 $this->query,


### PR DESCRIPTION
### WHY are these changes introduced?

* We should have always been sending the `application/json` as the content type.
* This will help us remain GraphQL spec compliant.

### WHAT is this pull request doing?

* Removes sending the `application/graphql` as the `Content-type` header

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
