### PR TITLE
[Fix] Fixed HMAC validation failure for query params with non url-safe characters

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -116,7 +116,7 @@ final class Utils
 
         return hash_equals(
             $params['hmac'],
-            hash_hmac('sha256', self::buildQueryString($params), $secret)
+            hash_hmac('sha256', urldecode(self::buildQueryString($params)), $secret)
         );
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #412 

When validating the hmac of a request, if some of the query params contain non url-safe characters, those are encoded, and the HMAC on our side is then computed based on that version. This differs from how the Shopify backend computes theirs, so the validation always fails

### WHAT is this pull request doing?

Decode the query string before computing its HMAC for validation

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

In practice, this will probably break downstreams, even though it's functionally a bugfix, so I'm marking it as a major change unless it's unnecessary.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
