### PR TITLE
Release version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## v6.0.0 - 2025-10-28
 - ⚠️ [Breaking] Remove `ApiVersion::LATEST` constant to prevent semver violations. The `apiVersion` parameter is now required in `Context::initialize()`. Developers must explicitly specify API versions. See the [migration guide](BREAKING_CHANGES_FOR_V6.md#removal-of-apiversionlatest-constant) for details.
 - [#425](https://github.com/Shopify/shopify-api-php/pull/425) [Patch] Add compliance webhook topics
 - [#433](https://github.com/Shopify/shopify-api-php/pull/433) [Minor] Add support for 2025-10 API version

--- a/src/version.php
+++ b/src/version.php
@@ -1,5 +1,5 @@
 <?php
 
 // @codeCoverageIgnoreStart
-return '5.11.0';
+return '6.0.0';
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
## Summary
This PR prepares the release of version 6.0.0 of the Shopify API PHP library.

## Changes Included in v6.0.0

### Breaking Changes
- ⚠️ **Remove `ApiVersion::LATEST` constant** to prevent semver violations
  - The `apiVersion` parameter is now **required** in `Context::initialize()`
  - Developers must explicitly specify API versions
  - See the [migration guide](BREAKING_CHANGES_FOR_V6.md) for details on updating your code

### New Features
- Add support for 2025-10 API version (#433)
- Add compliance webhook topics (#425)

## Migration Guide
For developers upgrading from v5.x to v6.0.0:
- Review [BREAKING_CHANGES_FOR_V6.md](BREAKING_CHANGES_FOR_V6.md) for detailed migration instructions
- The main change is explicitly specifying the API version instead of relying on `ApiVersion::LATEST`

## Files Modified
- `src/version.php` - Updated to version 6.0.0
- `CHANGELOG.md` - Added v6.0.0 release notes

## Testing
All existing tests should continue to pass. The breaking change requires apps to update their initialization code to specify an explicit API version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)