### PR TITLE
[Fix] Move sleep so it occurs only when retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Sleep before a retry rather than after each try.
 
 ## v6.0.0 - 2025-10-28
 - ⚠️ [Breaking] Remove `ApiVersion::LATEST` constant to prevent semver violations. The `apiVersion` parameter is now required in `Context::initialize()`. Developers must explicitly specify API versions. See the [migration guide](BREAKING_CHANGES_FOR_V6.md#removal-of-apiversionlatest-constant) for details.

--- a/src/Clients/Http.php
+++ b/src/Clients/Http.php
@@ -213,6 +213,9 @@ class Http
         $currentTries = 0;
         do {
             $currentTries++;
+            if ($currentTries > 1) {
+                usleep((int)($retryAfter * 1000000));
+            }
 
             $response = HttpResponse::fromResponse($client->sendRequest($request));
 
@@ -220,8 +223,6 @@ class Http
                 $retryAfter = $response->hasHeader(HttpHeaders::RETRY_AFTER)
                     ? $response->getHeaderLine(HttpHeaders::RETRY_AFTER)
                     : Context::$RETRY_TIME_IN_SECONDS;
-
-                usleep((int)($retryAfter * 1000000));
             } else {
                 break;
             }


### PR DESCRIPTION
### WHY are these changes introduced?
The current way this code is written, we always sleep after a retryable failure (429, 500). However, there are two scenarios:

1. We only want to try the request once. We then are sleeping before returning, even though we will break out of the loop immediately after.
2. We have multiple tries, but we have failed up to the limit. Again, we are sleeping before returning a response.

### WHAT is this pull request doing?
Moves the sleep statement to the beginning of the loop, executing only if we are on at least the second try.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)
