### PR TITLE
Preparing for release 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)
 
 ## v6.1.0 - 2026-01-21

--- a/src/version.php
+++ b/src/version.php
@@ -1,5 +1,5 @@
 <?php
 
 // @codeCoverageIgnoreStart
-return '6.1.0';
+return '6.1.1';
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
### WHY are these changes introduced?

Preparing for the v6.1.1 patch release.

### WHAT is this pull request doing?

- Updates `CHANGELOG.md` to move the unreleased entry under the `v6.1.1 - 2026-03-02` heading
- Bumps the version in `src/version.php` to `6.1.1`

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have updated the documentation for public APIs from the library (if applicable)