### PR TITLE
[Feature] Add support for GraphQL API 2026-04

### DIFF
--- a/BREAKING_CHANGES_FOR_V6.md
+++ b/BREAKING_CHANGES_FOR_V6.md
@@ -13,7 +13,7 @@ The `ApiVersion::LATEST` constant has been removed to prevent semantic versionin
 $apiVersion = ApiVersion::LATEST;
 
 // After (v6+)
-$apiVersion = '2025-07'; // Explicitly specify the version you want to use
+$apiVersion = '2026-04'; // Explicitly specify the version you want to use
 ```
 
 **In your Context::initialize():**
@@ -38,7 +38,7 @@ Context::initialize(
     scopes: $_ENV['SHOPIFY_APP_SCOPES'],
     hostName: $_ENV['SHOPIFY_APP_HOST_NAME'],
     sessionStorage: new FileSessionStorage('/tmp/php_sessions'),
-    apiVersion: '2025-07', // Now required - explicitly specify the version
+    apiVersion: '2026-04', // Now required - explicitly specify the version
 );
 ```
 
@@ -51,10 +51,11 @@ use Shopify\ApiVersion;
 
 // Available constants (as of this release):
 ApiVersion::UNSTABLE      // "unstable"
+ApiVersion::APRIL_2026    // "2026-04"
+ApiVersion::JANUARY_2026  // "2026-01"
+ApiVersion::OCTOBER_2025  // "2025-10"
 ApiVersion::JULY_2025     // "2025-07"
 ApiVersion::APRIL_2025    // "2025-04"
-ApiVersion::JANUARY_2025  // "2025-01"
-ApiVersion::OCTOBER_2024  // "2024-10"
 // ... and older versions
 ```
 
@@ -63,7 +64,7 @@ Or you can use string literals directly:
 ```php
 Context::initialize(
     // ... other parameters
-    apiVersion: '2025-07',
+    apiVersion: '2026-04',
 );
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- [Minor] Add support for 2026-04 GraphQL API version
 
 ## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)

--- a/REST_RESOURCE.md
+++ b/REST_RESOURCE.md
@@ -21,7 +21,7 @@ public const LATEST = self::JULY_2025;  // Update from previous latest
 
 **Naming Convention:**
 - Format: `{MONTH}_{YEAR}`
-- Examples: `APRIL_2025`, `JULY_2025`, `OCTOBER_2025`
+- Examples: `OCTOBER_2025`, `JANUARY_2026`, `APRIL_2026`
 
 ## Step 2: Create Directory Structure
 

--- a/src/ApiVersion.php
+++ b/src/ApiVersion.php
@@ -74,4 +74,8 @@ class ApiVersion
      * @var string
      */
     public const JANUARY_2026 = "2026-01";
+    /**
+     * @var string
+     */
+    public const APRIL_2026 = "2026-04";
 }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -22,7 +22,7 @@ class BaseTestCase extends TestCase
     /**
      * API version to use for tests. Uses the latest available version.
      */
-    protected const TEST_API_VERSION = ApiVersion::OCTOBER_2025;
+    protected const TEST_API_VERSION = ApiVersion::APRIL_2026;
 
     protected const TEST_API_SECRET = '7008c5f4da4718b9b45d26d3fcbbb157';
     protected const TEST_API_SECRET_ALT = 'b4f15c37e89a23d6c701f4e82a9d5f0b';

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -36,6 +36,7 @@ final class ContextTest extends BaseTestCase
         $this->assertEquals(new Scopes(['sleepy', 'kitty']), Context::$SCOPES);
         $this->assertEquals('my-friends-cats', Context::$HOST_NAME);
         $this->assertEquals('https', Context::$HOST_SCHEME);
+        $this->assertEquals(self::TEST_API_VERSION, Context::$API_VERSION);
 
         // This should not trigger the exception
         Context::throwIfUninitialized();


### PR DESCRIPTION
### WHY are these changes introduced?

No linked issue.

This pull request adds support for Shopify GraphQL API version `2026-04` in the PHP client and keeps the supporting docs and shared test defaults aligned with that version.

### WHAT is this pull request doing?

- adds `ApiVersion::APRIL_2026`
- updates the shared test API version default to `2026-04`
- adds a context assertion to verify the configured API version is retained
- updates version examples in `BREAKING_CHANGES_FOR_V6.md`
- updates version naming examples in `REST_RESOURCE.md`
- adds an unreleased changelog entry for `2026-04` GraphQL support

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
