### PR TITLE
Fix Session::isValid() to use inclusion-based scope validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Patch] Fix `Session::isValid()` to use inclusion-based scope validation so sessions with all configured scopes plus additional granted scopes are not incorrectly rejected. Aligns PHP SDK behaviour with the Node SDK.
+
 ## v6.1.1 - 2026-03-02
 - [#456](https://github.com/Shopify/shopify-api-php/pull/456) [Patch] Update firebase/php-jwt to ^7.0 to address security vulnerability (GHSA-2x45-7fc3-mxwq)
 

--- a/src/Auth/Session.php
+++ b/src/Auth/Session.php
@@ -143,11 +143,18 @@ class Session
     /**
      * Checks whether this session has all of the necessary settings to make requests to Shopify.
      *
+     * A session is considered valid when its granted scopes include all of the app's configured
+     * scopes (the session may have additional granted scopes beyond those required), it has an
+     * access token, and it has not expired. This inclusion-based check aligns with the Node SDK's
+     * scope validation behaviour and avoids rejecting valid sessions that were granted optional or
+     * additional scopes beyond the configured set.
+     *
      * @return bool
      */
     public function isValid(): bool
     {
-        return (Context::$SCOPES->equals($this->scope) &&
+        $sessionScopes = new Scopes($this->scope ?? []);
+        return ($sessionScopes->has(Context::$SCOPES) &&
             $this->accessToken &&
             (!$this->expires || ($this->expires > new DateTime()))
         );

--- a/tests/Auth/SessionTest.php
+++ b/tests/Auth/SessionTest.php
@@ -99,7 +99,22 @@ final class SessionTest extends BaseTestCase
         $this->assertTrue($session->isValid());
     }
 
-    public function testIsValidReturnsFalseIfScopesHaveChanged()
+    public function testIsValidReturnsTrueWhenSessionHasAdditionalGrantedScopes()
+    {
+        // Sessions with all configured scopes PLUS extra granted scopes must still be valid.
+        // This mirrors the Node SDK's inclusion-based scope check and prevents
+        // Utils::loadOfflineSession() from returning null for sessions that include optional scopes.
+        Context::$SCOPES = new Scopes('read_products');
+
+        $session = new Session('12345', 'my-shop.myshopify.io', true, '1234');
+        $session->setScope('read_products,write_orders');
+        $session->setExpires(strtotime('+10 minutes'));
+        $session->setAccessToken('totally_real_token');
+
+        $this->assertTrue($session->isValid());
+    }
+
+    public function testIsValidReturnsFalseIfScopesAreMissing()
     {
         Context::$SCOPES = new Scopes('read_products,write_orders');
 


### PR DESCRIPTION
### WHY are these changes introduced?

`Session::isValid()` currently validates scopes with exact equality:

```php
Context::$SCOPES->equals($this->scope)
```

This causes `Utils::loadOfflineSession($shop)` to return `null` when a stored offline session has **all required app scopes plus additional granted optional scopes**. The access token is still fully usable for Admin API calls that only require the configured scopes — extra granted scopes should not invalidate the session.

This bug can surface when a merchant grants optional/additional scopes during the OAuth flow (e.g. via Shopify's optional scopes feature), or when scope grants evolve over time without re-authentication. The session gets rejected even though it satisfies every scope the app actually needs.

### WHAT is this pull request doing?

Replaces the exact-equality scope check in `Session::isValid()` with an inclusion-based check using the existing `Scopes::has()` method:

```php
// Before
Context::$SCOPES->equals($this->scope)

// After
$sessionScopes = new Scopes($this->scope ?? []);
$sessionScopes->has(Context::$SCOPES)
```

A session is now valid as long as its granted scopes are a **superset** of the app's configured scopes. The access-token and expiry checks are unchanged.

This aligns the PHP SDK behaviour with the [Node SDK's inclusion-based scope validation](https://github.com/Shopify/shopify-app-js/tree/main/packages/apps/shopify-api), avoiding the rejection of valid offline sessions that include optional or additional granted scopes.

**Tests updated / added:**

| Scenario | Expected |
|---|---|
| Session with exactly the configured scopes | valid ✅ |
| Session with configured scopes **plus extra scopes** | valid ✅ (new) |
| Session missing one configured scope | invalid ❌ |
| Session without an access token | invalid ❌ |
| Expired session | invalid ❌ |

The previous test `testIsValidReturnsFalseIfScopesHaveChanged` tested a scenario (session has fewer scopes than configured) that is still correctly `false` under the new logic; it has been renamed to `testIsValidReturnsFalseIfScopesAreMissing` for clarity.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have updated the documentation for public APIs from the library (if applicable)
